### PR TITLE
Improve account book creation flow

### DIFF
--- a/Core/Sources/Core/Core/DataManager.swift
+++ b/Core/Sources/Core/Core/DataManager.swift
@@ -25,8 +25,12 @@ var ledgerClient: LedgerDataClient {
 
 public struct LedgerDataClient {
     public var fetchLedgers: @Sendable () async -> [AccountBook]
-    public var addLedger: @Sendable (_ title: String, _ ownerID: String) async -> Void // title, ownerID
+    public var addLedger: @Sendable (_ title: String, _ ownerID: String, _ ownerName: String) async throws -> AccountBook
     public var deleteLedger: @Sendable (String) async -> Void // ledger ID
+}
+
+public enum LedgerDataClientError: Error {
+    case saveFailed
 }
 
 extension LedgerDataClient {
@@ -39,16 +43,22 @@ extension LedgerDataClient {
             let models = ledgers.map(LedgerAdapter.from)
             return models
         },
-        addLedger: { title, ownerID in
+        addLedger: { title, ownerID, ownerName in
             let context = PersistenceController.shared.container.viewContext
             let ledger = LedgerEntity(context: context)
             ledger.id = UUID().uuidString
             ledger.title = title
             ledger.createdAt = Date()
             ledger.ownerID = ownerID
-            ledger.ownerName = nil
+            ledger.ownerName = ownerName
             ledger.recordName = UUID().uuidString
-            try? context.save()
+            do {
+                try context.save()
+            } catch {
+                context.rollback()
+                throw LedgerDataClientError.saveFailed
+            }
+            return LedgerAdapter.from(entity: ledger)
         },
         deleteLedger: { id in
             let context = PersistenceController.shared.container.viewContext
@@ -63,22 +73,28 @@ extension LedgerDataClient {
     
     public static let mock = LedgerDataClient {
         []
-    } addLedger: { title, ownerID in
-        
-    } deleteLedger: { ledgerID in
-        
-    }
+    } addLedger: { title, ownerID, ownerName in
+        AccountBook(
+            owner: .init(id: ownerID, name: ownerName),
+            participacer: [],
+            bills: [],
+            id: UUID().uuidString,
+            name: title,
+            createdAt: Date().ISO8601Format()
+        )
+    } deleteLedger: { _ in }
 
 }
 
 public struct LedgerAdapter {
     static func from(entity: LedgerEntity) -> AccountBook {
-        AccountBook(owner: .init(id: entity.ownerID ?? "", name: entity.ownerName ?? ""),
-                    participacer: entity.participacers?.convertToParticipacers(permission: .read) ?? [],
-                    bills: [],
-                    id: entity.id ?? "",
-                    name: entity.title ?? "",
-                    createdAt: "Date()"
+        AccountBook(
+            owner: .init(id: entity.ownerID ?? "", name: entity.ownerName ?? ""),
+            participacer: entity.participacers?.convertToParticipacers(permission: .read) ?? [],
+            bills: [],
+            id: entity.id ?? "",
+            name: entity.title ?? "",
+            createdAt: entity.createdAt?.ISO8601Format() ?? ""
         )
     }
 }

--- a/Feature/Sources/AccountBookConfig/AccountBookConfigStore.swift
+++ b/Feature/Sources/AccountBookConfig/AccountBookConfigStore.swift
@@ -10,7 +10,6 @@ import Core
 import Foundation
 import ParticipatorDetail
 import SwiftUI
-import CoreData
 
 @Reducer
 public struct AccountBookConfigStore {
@@ -22,23 +21,44 @@ public struct AccountBookConfigStore {
 
         var paticipators: [Participacer] = []
 
+        var originalName: String = ""
+
+        var isSaving: Bool = false
+
         var saveDisable: Bool {
-            name.isEmpty
+            trimmedName.isEmpty || isSaving
         }
-        
+
         var isCreate: Bool
 
         var sharedLink: String = ""
 
         var shouldShared: Bool = false
 
+        var trimmedName: String {
+            name.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var hasEdits: Bool {
+            if isCreate {
+                return !trimmedName.isEmpty
+            }
+            return trimmedName != originalName.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
         @Presents var destination: Destination.State?
+        @Presents var alert: AlertState<Action.Alert>?
 
         public init(
             book: AccountBook? = nil
         ) {
             self.book = book
             self.isCreate = book == nil
+            if let book {
+                self.name = book.name
+                self.originalName = book.name
+                self.paticipators = book.participacer
+            }
         }
     }
 
@@ -48,8 +68,16 @@ public struct AccountBookConfigStore {
         case tapUser(String?)
         case tapTopDone
         case tapTopCancel
+        case cancelConfirmed
+        case saveResponse(Result<AccountBook, Error>)
         case destination(PresentationAction<Destination.Action>)
+        case alert(PresentationAction<Alert>)
         case binding(BindingAction<State>)
+    
+        public enum Alert: Equatable {
+            case confirmDiscard
+            case acknowledgeFailure
+        }
     }
 
     @Dependency(\.ledgerClient) public var ledgerClient
@@ -64,8 +92,18 @@ public struct AccountBookConfigStore {
                 if let book = state.book {
                     state.name = book.name
                     state.paticipators = book.participacer
+                    state.originalName = book.name
+                    state.isCreate = false
+                } else {
+                    state.name = ""
+                    state.originalName = ""
+                    state.paticipators = []
+                    state.isCreate = true
                 }
                 state.destination = nil
+                state.shouldShared = false
+                state.sharedLink = ""
+                state.isSaving = false
                 return .none
             case .binding:
                 return .none
@@ -86,18 +124,78 @@ public struct AccountBookConfigStore {
                 state.destination = nil
                 return .none
             case .tapTopDone:
-//                DataManager.shared.createAccountBook(name: state.name) { error in
-//                    print("result is \(error)")
-//                }
-                // TODO: safe logics
+                if state.saveDisable {
+                    return .none
+                }
+                state.isSaving = true
+                if state.isCreate {
+                    let title = state.trimmedName
+                    let ownerID = state.book?.owner.id ?? UUID().uuidString
+                    let ownerName = state.book?.owner.name ?? "Owner"
                     return .run { send in
-                        await ledgerClient.addLedger("", "")
+                        await send(
+                            .saveResponse(
+                                TaskResult {
+                                    try await ledgerClient.addLedger(title, ownerID, ownerName)
+                                }
+                            )
+                        )
                     }
+                } else if var book = state.book {
+                    book.name = state.trimmedName
+                    state.book = book
+                    state.originalName = book.name
+                    return .send(.saveResponse(.success(book)))
+                }
+                return .none
+            case .saveResponse(.success(let book)):
+                state.book = book
+                state.isCreate = false
+                state.originalName = book.name
+                state.name = book.name
+                state.paticipators = book.participacer
+                state.isSaving = false
+                return .none
+            case .saveResponse(.failure):
+                state.isSaving = false
+                state.alert = AlertState(
+                    title: TextState("Save Failed"),
+                    message: TextState("Please try again."),
+                    buttons: [
+                        .default(TextState("OK"), action: .send(.acknowledgeFailure))
+                    ]
+                )
+                return .none
+            case .tapTopCancel:
+                if state.hasEdits {
+                    state.alert = AlertState(
+                        title: TextState("Discard changes?"),
+                        message: TextState("Your current edits will be lost."),
+                        buttons: [
+                            .destructive(TextState("Discard"), action: .send(.confirmDiscard)),
+                            .cancel(TextState("Keep Editing"))
+                        ]
+                    )
+                    return .none
+                }
+                return .send(.cancelConfirmed)
+            case .cancelConfirmed:
+                state.alert = nil
+                state.isSaving = false
+                return .none
+            case .alert(.presented(.confirmDiscard)):
+                return .send(.cancelConfirmed)
+            case .alert(.presented(.acknowledgeFailure)):
+                state.alert = nil
+                return .none
+            case .alert:
+                return .none
             default:
                 return .none
             }
         }
         .ifLet(\.$destination, action: \.destination)
+        .ifLet(\.$alert, action: \.alert)
     }
 
     @Reducer

--- a/Feature/Sources/AccountBookConfig/AccountBookConfigView.swift
+++ b/Feature/Sources/AccountBookConfig/AccountBookConfigView.swift
@@ -25,7 +25,7 @@ public struct AccountBookConfigView: View {
     public var body: some View {
         NavigationStack {
             scrollView
-            .navigationTitle("Account Book")
+            .navigationTitle(store.isCreate ? "add account book" : "edit account book")
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(action: {
@@ -52,11 +52,12 @@ public struct AccountBookConfigView: View {
             //                    // make icloudSharedController
             //                }
         }
+        .alert($store.scope(state: \.alert, action: \.alert))
         .onAppear {
             store.send(.onAppear)
         }
     }
-    
+
     var scrollView: some View {
         ScrollView {
             VStack(alignment: .leading) {
@@ -64,16 +65,17 @@ public struct AccountBookConfigView: View {
                     .font(.headline)
                 TextField("Name Your Account Book", text: $store.name)
                     .textFieldStyle(.roundedBorder)
-                
-                
-                Group {
-                    Text("Participators")
-                        .font(.headline)
-                    LazyVGrid(columns: gridItems) {
-                        ForEach(0 ... store.paticipators.count, id: \.self) {
-                            let model = $0 == store.paticipators.count ? nil : store.paticipators[$0]
-                            ParticipatorView(user: model) { user in
-                                store.send(.tapUser(user?.id))
+
+                if !store.isCreate {
+                    Group {
+                        Text("Participators")
+                            .font(.headline)
+                        LazyVGrid(columns: gridItems) {
+                            ForEach(0 ... store.paticipators.count, id: \.self) {
+                                let model = $0 == store.paticipators.count ? nil : store.paticipators[$0]
+                                ParticipatorView(user: model) { user in
+                                    store.send(.tapUser(user?.id))
+                                }
                             }
                         }
                     }

--- a/Feature/Sources/AccountBookList/AccountBooklistStore.swift
+++ b/Feature/Sources/AccountBookList/AccountBooklistStore.swift
@@ -52,11 +52,13 @@ public struct AccountBooklistStore {
         case tapDetail(bookID: String)
         case setPresent(Bool)
         case removeItem(IndexSet)
+        case booksResponse([AccountBook])
         case binding(BindingAction<State>)
         case accountBookConfig(AccountBookConfigStore.Action)
     }
 
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.ledgerClient) var ledgerClient
 
     public init() {}
 
@@ -65,7 +67,9 @@ public struct AccountBooklistStore {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                return .none
+                return .run { send in
+                    await send(.booksResponse(await ledgerClient.fetchLedgers()))
+                }
             case .addBook:
                 state.accountBookConfig = .init()
                 return .run { send in
@@ -92,6 +96,15 @@ public struct AccountBooklistStore {
                 state.saveDisable = true
                 state.books.remove(atOffsets: index)
                 return .none
+            case let .booksResponse(books):
+                state.books = books
+                if let selected, !books.contains(where: { $0.id == selected }) {
+                    state.selected = nil
+                    state.saveDisable = true
+                } else {
+                    state.saveDisable = state.selected == nil
+                }
+                return .none
 //            case .binding(let $dd):
 ////                
 ////                state.saveDisable = state.selected == nil
@@ -99,13 +112,18 @@ public struct AccountBooklistStore {
             case .binding:
                 return .none
             case .accountBookConfig(.tapTopCancel):
-                state.isShouldPresent = false
-                // config cancel
                 return .none
-            case .accountBookConfig(.tapTopDone):
+            case .accountBookConfig(.cancelConfirmed):
                 state.isShouldPresent = false
-                // config Done
-                // TODO: save action need be add
+                state.accountBookConfig = .init()
+                return .none
+            case .accountBookConfig(.saveResponse(.success)):
+                state.isShouldPresent = false
+                state.accountBookConfig = .init()
+                return .run { send in
+                    await send(.booksResponse(await ledgerClient.fetchLedgers()))
+                }
+            case .accountBookConfig(.saveResponse(.failure)):
                 return .none
             default:
                 return .none


### PR DESCRIPTION
## Summary
- track the save in-flight state in the account book configuration reducer to gate the Save button and reuse TaskResult for creation
- refresh account books from the ledger client on appearance and after successful saves instead of mutating the local list manually

## Testing
- swift test *(fails: repository has no Package.swift to build)*

------
https://chatgpt.com/codex/tasks/task_e_68cb93dac9c4832eb94f6551b2fdb03f