### PR TITLE
Enforce ledger context and default currency for bill entry

### DIFF
--- a/Core/Sources/Core/Core/DataManager.swift
+++ b/Core/Sources/Core/Core/DataManager.swift
@@ -33,6 +33,26 @@ public enum LedgerDataClientError: Error {
     case saveFailed
 }
 
+public enum TransactionDataClientKey: DependencyKey {
+  public static let liveValue: TransactionDataClient = .live
+}
+
+public extension DependencyValues {
+var transactionClient: TransactionDataClient {
+    get { self[TransactionDataClientKey.self] }
+    set { self[TransactionDataClientKey.self] = newValue }
+  }
+}
+
+public struct TransactionDataClient {
+    public var addBill: @Sendable (_ ledger: AccountBook, _ value: Double, _ type: BillType, _ mainCategory: BillMainCategory, _ subCategory: BillSubCategory, _ date: Date, _ description: String?) async throws -> Bill
+}
+
+public enum TransactionDataClientError: Error {
+    case ledgerNotFound
+    case saveFailed
+}
+
 extension LedgerDataClient {
     public static let live = LedgerDataClient(
         fetchLedgers: {
@@ -86,6 +106,47 @@ extension LedgerDataClient {
 
 }
 
+extension TransactionDataClient {
+    public static let live = TransactionDataClient { ledger, value, type, mainCategory, subCategory, date, description in
+        let context = PersistenceController.shared.container.viewContext
+
+        let request: NSFetchRequest<LedgerEntity> = LedgerEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", ledger.id)
+
+        let ledgerResults = try context.fetch(request)
+        guard let ledgerEntity = ledgerResults.first else {
+            throw TransactionDataClientError.ledgerNotFound
+        }
+
+        let transaction = TransactionEntity(context: context)
+        transaction.id = UUID()
+        transaction.value = value
+        transaction.type = type.rawValue
+        transaction.createdAt = date
+        transaction.updatedAt = date
+        transaction.descriptionContent = description
+        transaction.book = ledgerEntity
+
+        let mainCategoryEntity = try fetchOrCreateMainCategoryEntity(from: mainCategory, context: context)
+        let subCategoryEntity = try fetchOrCreateSubCategoryEntity(from: subCategory, mainCategoryEntity: mainCategoryEntity, context: context)
+        let userEntity = try fetchOrCreateUserEntity(from: ledger.owner, context: context)
+
+        transaction.mainCategory = mainCategoryEntity
+        transaction.subCategory = subCategoryEntity
+        transaction.createdByUser = userEntity
+        transaction.updatedByUser = userEntity
+
+        do {
+            try context.save()
+        } catch {
+            context.rollback()
+            throw TransactionDataClientError.saveFailed
+        }
+
+        return BillAdapter.from(entity: transaction)
+    }
+}
+
 public struct LedgerAdapter {
     static func from(entity: LedgerEntity) -> AccountBook {
         // owner 对象
@@ -130,7 +191,7 @@ public struct BillAdapter {
     static func from(entity: TransactionEntity) -> Bill {
         // 账单类型
         let billType = BillType(rawValue: entity.type ?? "0") ?? .payment
-        
+
         // 主分类
         let mainCategory = BillMainCategory(
             id: entity.mainCategory?.id?.uuidString ?? "",
@@ -171,6 +232,77 @@ public struct BillAdapter {
             description: entity.descriptionContent ?? ""
         )
     }
+}
+
+private func fetchOrCreateMainCategoryEntity(from category: BillMainCategory, context: NSManagedObjectContext) throws -> BillMainCategoryEntity {
+    let request: NSFetchRequest<BillMainCategoryEntity> = BillMainCategoryEntity.fetchRequest()
+    if let uuid = UUID(uuidString: category.id) {
+        request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+    } else {
+        request.predicate = NSPredicate(value: false)
+    }
+
+    if let existing = try context.fetch(request).first {
+        existing.name = category.name
+        return existing
+    }
+
+    let entity = BillMainCategoryEntity(context: context)
+    if let uuid = UUID(uuidString: category.id) {
+        entity.id = uuid
+    } else {
+        entity.id = UUID()
+    }
+    entity.name = category.name
+    return entity
+}
+
+private func fetchOrCreateSubCategoryEntity(from category: BillSubCategory, mainCategoryEntity: BillMainCategoryEntity, context: NSManagedObjectContext) throws -> BillSubCategoryEntity {
+    let request: NSFetchRequest<BillSubCategoryEntity> = BillSubCategoryEntity.fetchRequest()
+    if let uuid = UUID(uuidString: category.id) {
+        request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+    } else {
+        request.predicate = NSPredicate(value: false)
+    }
+
+    if let existing = try context.fetch(request).first {
+        existing.name = category.name
+        existing.mainCategory = mainCategoryEntity
+        return existing
+    }
+
+    let entity = BillSubCategoryEntity(context: context)
+    if let uuid = UUID(uuidString: category.id) {
+        entity.id = uuid
+    } else {
+        entity.id = UUID()
+    }
+    entity.name = category.name
+    entity.mainCategory = mainCategoryEntity
+    return entity
+}
+
+private func fetchOrCreateUserEntity(from user: User, context: NSManagedObjectContext) throws -> UserEntity {
+    let request: NSFetchRequest<UserEntity> = UserEntity.fetchRequest()
+    if let uuid = UUID(uuidString: user.id) {
+        request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+    } else {
+        request.predicate = NSPredicate(value: false)
+    }
+
+    if let existing = try context.fetch(request).first {
+        existing.name = user.name
+        return existing
+    }
+
+    let entity = UserEntity(context: context)
+    if let uuid = UUID(uuidString: user.id) {
+        entity.id = uuid
+    } else {
+        entity.id = UUID()
+    }
+    entity.name = user.name
+    return entity
 }
 
 class PersistenceController {

--- a/Feature/Sources/Billslist/BillslistStore.swift
+++ b/Feature/Sources/Billslist/BillslistStore.swift
@@ -18,13 +18,16 @@ public struct BillslistStore {
     @ObservableState
     public struct State{
         var bills: [BillSectionData] = .stub()
+        var ledger: AccountBook
         @Presents var destination: Destination.State?
 
         public init(
             bills: [BillSectionData] = .stub(),
+            ledger: AccountBook = .placeholder,
             destination: Destination.State? = nil
         ) {
             self.bills = bills
+            self.ledger = ledger
             self.destination = destination
         }
     }
@@ -34,16 +37,22 @@ public struct BillslistStore {
         case tapSetting
         case tapAdd(BillType?)
         case onTap(Bill)
+        case ledgersResponse([AccountBook])
         case destination(PresentationAction<Destination.Action>)
     }
 
     public init() {}
 
+    @Dependency(\.ledgerClient) var ledgerClient
+
     public var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                return .none
+                return .run { send in
+                    let ledgers = await ledgerClient.fetchLedgers()
+                    await send(.ledgersResponse(ledgers))
+                }
             case let .onTap(bill):
                 state.destination = .billDetail(.init(billModel: bill))
                 return .none
@@ -51,7 +60,28 @@ public struct BillslistStore {
                 state.destination = .setting(.init())
                 return .none
             case .tapAdd(nil):
-                state.destination = .addAccounts(.init())
+                state.destination = .addAccounts(.init(ledger: state.ledger))
+                return .none
+            case .tapAdd(let type?):
+                state.destination = .addAccounts(
+                    .init(
+                        ledger: state.ledger,
+                        selectedBillType: type,
+                        title: type == .income ? "Income" : "Payment"
+                    )
+                )
+                return .none
+            case .ledgersResponse(let ledgers):
+                guard !ledgers.isEmpty else {
+                    state.bills = []
+                    return .none
+                }
+                if let matched = ledgers.first(where: { $0.id == state.ledger.id }) {
+                    state.ledger = matched
+                } else if let first = ledgers.first {
+                    state.ledger = first
+                }
+                state.bills = Self.makeBillSections(from: state.ledger)
                 return .none
             default:
                 return .none
@@ -66,5 +96,29 @@ public struct BillslistStore {
         case setting(SettingStore)
         case addAccounts(InputAccountsStore)
     }
-    
+
+}
+
+private extension BillslistStore {
+    static func makeBillSections(from ledger: AccountBook) -> [BillSectionData] {
+        guard !ledger.bills.isEmpty else { return [] }
+        return [
+            BillSectionData(
+                id: ledger.id,
+                header: ledger.name,
+                cells: ledger.bills.sorted(by: { $0.updatedAt > $1.updatedAt })
+            )
+        ]
+    }
+}
+
+private extension AccountBook {
+    static let placeholder = AccountBook(
+        owner: .init(id: "", name: ""),
+        participacer: [],
+        bills: [],
+        id: "",
+        name: "",
+        createdAt: ""
+    )
 }

--- a/Feature/Sources/InputAccounts/InputAccountsStore.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsStore.swift
@@ -28,27 +28,50 @@ public struct InputAccountsStore {
         var billsType: [BillType]
         var selectedBillType: BillType
         var showPhotoLib = false
+        var ledger: AccountBook
+        var selectedCurrency: CurrencyModel
+        var selectedMainCategory: BillMainCategory?
+        var selectedSubCategory: BillSubCategory?
+        var memo: String
+        var isSaving: Bool
         var currentOperator: Operator?
         var currentOperand: String?
-        
+
         @Presents var destination: Destination.State?
         @Presents var choosePhotoDialog: ConfirmationDialogState<Action.ChoosePhotoDialog>?
+        @Presents var alert: AlertState<Action.Alert>?
 
-        public init(title: String = "Payment", 
+        public init(title: String = "Payment",
                     inputValue: String = "",
                     inputDate: Date = .now, // TODO: add date to env DI.
                     inputPlaceholder: String = "0.00",
                     tapPlus: Bool = false,
                     billsType: [BillType] = [.income, .payment],
-                    selectedBillType: BillType = .payment
+                    selectedBillType: BillType = .payment,
+                    ledger: AccountBook = .placeholderLedger,
+                    selectedCurrency: CurrencyModel = .usd,
+                    selectedMainCategory: BillMainCategory? = nil,
+                    selectedSubCategory: BillSubCategory? = nil,
+                    memo: String = "",
+                    isSaving: Bool = false
         ) {
-            self.title = title
+            if title.isEmpty {
+                self.title = selectedBillType == .income ? "Income" : "Payment"
+            } else {
+                self.title = title
+            }
             self.inputValue = inputValue
             self.inputDate = inputDate
             self.tapPlus = tapPlus
             self.billsType = billsType
             self.inputPlaceholder = inputPlaceholder
             self.selectedBillType = selectedBillType
+            self.ledger = ledger
+            self.selectedCurrency = selectedCurrency
+            self.selectedMainCategory = selectedMainCategory
+            self.selectedSubCategory = selectedSubCategory
+            self.memo = memo
+            self.isSaving = isSaving
         }
     }
 
@@ -70,21 +93,28 @@ public struct InputAccountsStore {
         case setInputValue(String)
         case tapBigCategory(BillMainCategory?)
         case tapSubCategory(BillSubCategory?)
-        case tapCurrency(CurrencyModel?)
+        case tapCurrency
         case input(AccountInput)
 //        case binding(BindingAction<State>)
         case destination(PresentationAction<Destination.Action>)
         case tapChoosePhoto
         case choosePhotoDialog(PresentationAction<ChoosePhotoDialog>)
+        case tapRecord
+        case saveResponse(Result<Bill, Error>)
+        case alert(PresentationAction<Alert>)
         @CasePathable
         public enum ChoosePhotoDialog: Equatable {
             case fromCamera
             case fromLibrary
         }
+        public enum Alert: Equatable {
+            case acknowledge
+        }
     }
-    
-    
+
+
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.transactionClient) var transactionClient
 
     public init() {}
 
@@ -100,15 +130,31 @@ public struct InputAccountsStore {
                 }
             case .billsType(let value):
                 state.selectedBillType = value
+                state.title = value == .income ? "Income" : "Payment"
                 return .none
             case .tapBigCategory(let category):
-                state.destination = .selectCategory(.init(selectedCategory: category))
+                state.destination = .selectCategory(
+                    .init(
+                        selectedCategory: category ?? state.selectedMainCategory
+                    )
+                )
                 return .none
             case .tapSubCategory(let category):
-                state.destination = .selectSubCategory(.init(selectedSubCategory: category))
+                let selected = category ?? state.selectedSubCategory
+                let subCategories = state.selectedMainCategory?.subCategories ?? []
+                state.destination = .selectSubCategory(
+                    .init(
+                        subCategories: subCategories,
+                        selectedSubCategory: selected
+                    )
+                )
                 return .none
-            case .tapCurrency(let currency):
-                state.destination = .selectCurrency(.init(selectedCurrency: currency))
+            case .tapCurrency:
+                state.destination = .selectCurrency(
+                    .init(
+                        selectedCurrency: state.selectedCurrency
+                    )
+                )
                 return .none
             case .tapChoosePhoto:
                 state.choosePhotoDialog = .init(title: {
@@ -164,14 +210,77 @@ public struct InputAccountsStore {
                 default:
                     return setNumber(state: &state, value: value)
                 }
+            case .destination(.presented(.selectCategory(.onTap(let category)))):
+                state.selectedMainCategory = category
+                state.selectedSubCategory = nil
+                state.destination = nil
+                return .none
+            case .destination(.presented(.selectSubCategory(.onTap(let category)))):
+                state.selectedSubCategory = category
+                state.destination = nil
+                return .none
+            case .destination(.presented(.selectCurrency(.onTap(let currency)))):
+                state.selectedCurrency = currency
+                state.destination = nil
+                return .none
+            case .tapRecord:
+                guard !state.isSaving else { return .none }
+                guard let value = Double(state.inputValue) else {
+                    state.alert = Self.makeAlert(message: "金額を入力してください。")
+                    return .none
+                }
+                let mainCategory = state.selectedMainCategory ?? BillMainCategory(id: UUID().uuidString, name: "未分類", subCategories: [])
+                let subCategory = state.selectedSubCategory ?? BillSubCategory(id: UUID().uuidString, name: "未分類")
+                var descriptionText = state.memo
+                let currency = state.selectedCurrency.shortName
+                if !currency.isEmpty {
+                    if descriptionText.isEmpty {
+                        descriptionText = "Currency: \(currency)"
+                    } else {
+                        descriptionText += " | Currency: \(currency)"
+                    }
+                }
+                state.isSaving = true
+                let billType = state.selectedBillType
+                let date = state.inputDate
+                let ledger = state.ledger
+                return .run { send in
+                    let result = await Result {
+                        try await transactionClient.addBill(
+                            ledger,
+                            value,
+                            billType,
+                            mainCategory,
+                            subCategory,
+                            date,
+                            descriptionText.isEmpty ? nil : descriptionText
+                        )
+                    }
+                    await send(.saveResponse(result))
+                }
+            case .saveResponse(.success):
+                state.isSaving = false
+                return .run { _ in
+                    await self.dismiss()
+                }
+            case .saveResponse(.failure):
+                state.isSaving = false
+                state.alert = Self.makeAlert(message: "保存に失敗しました。再試行してください。")
+                return .none
+            case .alert(.presented(.acknowledge)):
+                state.alert = nil
+                return .none
+            case .alert:
+                return .none
             default:
                 return .none
             }
         }
         .ifLet(\.$destination, action: \.destination)
         .ifLet(\.$choosePhotoDialog, action: \.choosePhotoDialog)
+        .ifLet(\.$alert, action: \.alert)
     }
-    
+
     func setNumber(state: inout State, value: AccountInput) -> Effect<Action> {
         if Operator.allCasesValue.contains(state.inputValue) {
             state.inputValue = ""
@@ -213,6 +322,40 @@ public struct InputAccountsStore {
         case fromCamera
         case fromLibrary
     }
+}
+
+private extension InputAccountsStore {
+    struct Constants {
+        static let usdCurrency = CurrencyModel(shortName: "USD", fullName: "United States Dollar", rate: 1)
+        static let placeholderLedger = AccountBook(
+            owner: .init(id: "", name: ""),
+            participacer: [],
+            bills: [],
+            id: "",
+            name: "",
+            createdAt: ""
+        )
+    }
+
+    static func makeAlert(message: String) -> AlertState<Action.Alert> {
+        AlertState(
+            title: { TextState("エラー") },
+            actions: {
+                ButtonState(action: .acknowledge) {
+                    TextState("OK")
+                }
+            },
+            message: { TextState(message) }
+        )
+    }
+}
+
+private extension AccountBook {
+    static var placeholderLedger: AccountBook { InputAccountsStore.Constants.placeholderLedger }
+}
+
+private extension CurrencyModel {
+    static var usd: CurrencyModel { InputAccountsStore.Constants.usdCurrency }
 }
 
 extension BillType {

--- a/Feature/Sources/InputAccounts/InputAccountsView.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsView.swift
@@ -56,6 +56,7 @@ public struct InputAccountsView: View {
             store.send(.onAppear)
         })
         .confirmationDialog($store.scope(state: \.choosePhotoDialog, action: \.choosePhotoDialog))
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 
     var scrollView: some View {
@@ -80,10 +81,10 @@ public struct InputAccountsView: View {
                 Group {
                     HStack {
                         Button(action: {
-                            store.send(.tapCurrency(nil))
+                            store.send(.tapCurrency)
                         }, label: {
                             HStack {
-                                Text("USD") // TODO: update here to real data.
+                                Text(store.selectedCurrency.shortName)
                                     .font(.system(size: 20, weight: .bold))
                                 Image(systemName: "chevron.down")
                             }
@@ -122,12 +123,11 @@ public struct InputAccountsView: View {
                 Group {
                     HStack {
                         Button {
-                            // TODO: add real params.
-                            store.send(.tapBigCategory(nil))
+                            store.send(.tapBigCategory(store.selectedMainCategory))
                         } label: {
                             HStack {
                                 VStack {
-                                    Text("大分類")
+                                    Text(store.selectedMainCategory?.name ?? "大分類")
                                         .font(.system(size: 20))
                                     Spacer()
                                 }
@@ -149,12 +149,11 @@ public struct InputAccountsView: View {
                 Group {
                     HStack {
                         Button {
-                            // TODO: add real params.
-                            store.send(.tapSubCategory(nil))
+                            store.send(.tapSubCategory(store.selectedSubCategory))
                         } label: {
                             HStack {
                                 VStack {
-                                    Text("小分類")
+                                    Text(store.selectedSubCategory?.name ?? "小分類")
                                         .font(.system(size: 20))
                                     Spacer()
                                 }
@@ -208,12 +207,16 @@ public struct InputAccountsView: View {
                 Spacer()
                 Group {
                     Button {
-                        
+                        store.send(.tapRecord)
                     } label: {
                         HStack {
                             Spacer()
-                            Text("Record")
-                                .font(.system(size: 24, weight: .bold))
+                            if store.isSaving {
+                                ProgressView()
+                            } else {
+                                Text("Record")
+                                    .font(.system(size: 24, weight: .bold))
+                            }
                             Spacer()
                         }
                     }
@@ -221,7 +224,8 @@ public struct InputAccountsView: View {
                     .background(Color.black)
                     .foregroundStyle(Color.white)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
-                                                
+                    .disabled(store.isSaving)
+
                 }
             }
         }

--- a/Feature/Sources/Root/RootStore.swift
+++ b/Feature/Sources/Root/RootStore.swift
@@ -79,7 +79,8 @@ public struct RootStore {
                         return .none
                     }
                     let billsState = BillslistStore.State(
-                        bills: Self.makeBillSections(from: ledger)
+                        bills: Self.makeBillSections(from: ledger),
+                        ledger: ledger
                     )
                     state.bills = billsState
                     state.destination = .billslist(billsState)
@@ -90,9 +91,13 @@ public struct RootStore {
 //                state.destination = nil
                 if let book = state.bookConfig.book {
                     let billSections = Self.makeBillSections(from: book)
-                    state.destination = .billslist(BillslistStore.State(bills: billSections))
+                    let billsState = BillslistStore.State(bills: billSections, ledger: book)
+                    state.bills = billsState
+                    state.destination = .billslist(billsState)
                 } else {
-                    state.destination = .billslist(BillslistStore.State(bills: []))
+                    let billsState = BillslistStore.State(bills: [])
+                    state.bills = billsState
+                    state.destination = .billslist(billsState)
                 }
                 return .none
             default:


### PR DESCRIPTION
## Summary
- require a non-optional ledger when presenting the bills list and propagate refreshed ledgers back into the active state
- ensure the input accounts store always has a ledger context and a default USD currency while opening the picker from the view
- keep the root flow in sync with the new initializer defaults when presenting the bills screen

## Testing
- swift build *(fails: unable to clone dependencies in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba9af0de4832eab3eb199304bf09e