### PR TITLE
Implement CloudKit-backed currency syncing

### DIFF
--- a/Core/Sources/Core/Core/DataManager.swift
+++ b/Core/Sources/Core/Core/DataManager.swift
@@ -53,6 +53,103 @@ public enum TransactionDataClientError: Error {
     case saveFailed
 }
 
+public enum CurrencyDataClientKey: DependencyKey {
+    public static let liveValue: CurrencyDataClient = .live
+}
+
+public extension DependencyValues {
+    var currencyClient: CurrencyDataClient {
+        get { self[CurrencyDataClientKey.self] }
+        set { self[CurrencyDataClientKey.self] = newValue }
+    }
+}
+
+public struct CurrencyDataClient {
+    public var fetchLocalCurrencies: @Sendable () async -> [CurrencyModel]
+    public var syncFromCloud: @Sendable () async throws -> [CurrencyModel]
+}
+
+public enum CurrencyDataClientError: LocalizedError {
+    case saveFailed(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .saveFailed(error):
+            return "保存汇率数据失败：\(error.localizedDescription)"
+        }
+    }
+}
+
+extension CurrencyDataClient {
+    public static let live = CurrencyDataClient(
+        fetchLocalCurrencies: {
+            let context = PersistenceController.shared.container.viewContext
+            return await fetchCurrencies(in: context)
+        },
+        syncFromCloud: {
+            let database = CKContainer(identifier: Config.containerIdentifier).publicCloudDatabase
+            let records = try await fetchCurrencyRecords(from: database)
+            let models = records.compactMap(CurrencyModel.init(record:))
+            let latestByRecordName = models.reduce(into: [String: CurrencyModel]()) { partialResult, model in
+                if let existing = partialResult[model.recordName], existing.modifiedAt >= model.modifiedAt {
+                    return
+                }
+                partialResult[model.recordName] = model
+            }
+            let syncedRecordNames = Set(latestByRecordName.keys)
+
+            let container = PersistenceController.shared.container
+            let backgroundContext = container.newBackgroundContext()
+            backgroundContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+            try await backgroundContext.perform {
+                let fetchRequest = NSFetchRequest<CurrencyEntity>(entityName: "CurrencyEntity")
+                let existingEntities = try backgroundContext.fetch(fetchRequest)
+                var entitiesByRecordName: [String: CurrencyEntity] = [:]
+
+                for entity in existingEntities {
+                    guard let recordName = entity.recordName else {
+                        backgroundContext.delete(entity)
+                        continue
+                    }
+
+                    if syncedRecordNames.contains(recordName) {
+                        entitiesByRecordName[recordName] = entity
+                    } else {
+                        backgroundContext.delete(entity)
+                    }
+                }
+
+                for (recordName, model) in latestByRecordName {
+                    let entity = entitiesByRecordName[recordName] ?? CurrencyEntity(context: backgroundContext)
+                    model.apply(to: entity)
+                    entitiesByRecordName[recordName] = entity
+                }
+
+                if backgroundContext.hasChanges {
+                    do {
+                        try backgroundContext.save()
+                    } catch {
+                        backgroundContext.reset()
+                        throw CurrencyDataClientError.saveFailed(error)
+                    }
+                }
+            }
+
+            return await fetchCurrencies(in: container.viewContext)
+        }
+    )
+
+    public static let stub = CurrencyDataClient(
+        fetchLocalCurrencies: {
+            [CurrencyModel].stub()
+        },
+        syncFromCloud: {
+            [CurrencyModel].stub()
+        }
+    )
+}
+
 extension LedgerDataClient {
     public static let live = LedgerDataClient(
         fetchLedgers: {
@@ -145,6 +242,49 @@ extension TransactionDataClient {
 
         return BillAdapter.from(entity: transaction)
     }
+}
+
+private func fetchCurrencies(in context: NSManagedObjectContext) async -> [CurrencyModel] {
+    await context.perform {
+        let request = NSFetchRequest<CurrencyEntity>(entityName: "CurrencyEntity")
+        request.sortDescriptors = [NSSortDescriptor(key: "shortName", ascending: true)]
+        let entities = (try? context.fetch(request)) ?? []
+        return entities.compactMap { $0.toModel() }
+    }
+}
+
+private func fetchCurrencyRecords(from database: CKDatabase) async throws -> [CKRecord] {
+    var allRecords: [CKRecord] = []
+    var cursor: CKQueryOperation.Cursor?
+
+    repeat {
+        if let cursor {
+            let response = try await database.records(continuingMatchFrom: cursor)
+            try response.matchResults.forEach { _, result in
+                switch result {
+                case let .success(record):
+                    allRecords.append(record)
+                case let .failure(error):
+                    throw error
+                }
+            }
+            cursor = response.queryCursor
+        } else {
+            let query = CKQuery(recordType: "Currency", predicate: NSPredicate(value: true))
+            let response = try await database.records(matching: query)
+            try response.matchResults.forEach { _, result in
+                switch result {
+                case let .success(record):
+                    allRecords.append(record)
+                case let .failure(error):
+                    throw error
+                }
+            }
+            cursor = response.queryCursor
+        }
+    } while cursor != nil
+
+    return allRecords
 }
 
 public struct LedgerAdapter {

--- a/Core/Sources/Core/Core/Models.swift
+++ b/Core/Sources/Core/Core/Models.swift
@@ -4,6 +4,8 @@
 //
 //  Created by Marcos Meng on 2022/08/04.
 //
+import CloudKit
+import CoreData
 import Domain
 import Foundation
 
@@ -191,21 +193,107 @@ public extension BillSubCategory {
     static let none = BillSubCategory(id: "", name: "")
 }
 
-public struct CurrencyModel: Equatable {
-    public let shortName: String
-    public let fullName: String
-    public let rate: CGFloat
-    
-    public init(shortName: String, fullName: String, rate: CGFloat) {
+public struct CurrencyModel: Equatable, Identifiable {
+    public var recordName: String
+    public var shortName: String
+    public var fullName: String
+    public var rate: Double
+    public var modifiedAt: Date
+
+    public var id: String { recordName }
+
+    public init(recordName: String, shortName: String, fullName: String, rate: Double, modifiedAt: Date) {
+        self.recordName = recordName
         self.shortName = shortName
         self.fullName = fullName
         self.rate = rate
+        self.modifiedAt = modifiedAt
     }
 }
 
 public extension CurrencyModel {
-    static let usd = CurrencyModel(shortName: "USD", fullName: "United States Dollar", rate: 1)
-    static let none = CurrencyModel(shortName: "", fullName: "", rate: 0)
+    static let usd = CurrencyModel(
+        recordName: "USD",
+        shortName: "USD",
+        fullName: "United States Dollar",
+        rate: 1,
+        modifiedAt: .distantPast
+    )
+    static let none = CurrencyModel(
+        recordName: "",
+        shortName: "",
+        fullName: "",
+        rate: 0,
+        modifiedAt: .distantPast
+    )
+}
+
+public extension CurrencyModel {
+    init?(entity: CurrencyEntity) {
+        guard let recordName = entity.recordName,
+              let shortName = entity.shortName,
+              let fullName = entity.fullName
+        else { return nil }
+
+        let modifiedAt = entity.modifiedAt ?? .distantPast
+        self.init(
+            recordName: recordName,
+            shortName: shortName,
+            fullName: fullName,
+            rate: entity.rate,
+            modifiedAt: modifiedAt
+        )
+    }
+
+    init?(record: CKRecord) {
+        guard let shortName = record["shortName"] as? String,
+              let fullName = record["fullName"] as? String,
+              let rate = record["rate"] as? Double
+        else { return nil }
+
+        let modifiedAt = record.modificationDate ?? record.creationDate ?? .distantPast
+        self.init(
+            recordName: record.recordID.recordName,
+            shortName: shortName,
+            fullName: fullName,
+            rate: rate,
+            modifiedAt: modifiedAt
+        )
+    }
+
+    func apply(to entity: CurrencyEntity) {
+        entity.recordName = recordName
+        entity.shortName = shortName
+        entity.fullName = fullName
+        entity.rate = rate
+        entity.modifiedAt = modifiedAt
+    }
+
+    func makeRecord(existingRecord: CKRecord? = nil) -> CKRecord {
+        let record: CKRecord
+        if let existingRecord {
+            record = existingRecord
+        } else {
+            let recordID = CKRecord.ID(recordName: recordName)
+            record = CKRecord(recordType: "Currency", recordID: recordID)
+        }
+        record["shortName"] = shortName as CKRecordValue
+        record["fullName"] = fullName as CKRecordValue
+        record["rate"] = NSNumber(value: rate)
+        return record
+    }
+}
+
+public extension CurrencyEntity {
+    func toModel() -> CurrencyModel? {
+        CurrencyModel(entity: self)
+    }
+}
+
+public extension CKRecord {
+    func toCurrencyModel() -> CurrencyModel? {
+        CurrencyModel(record: self)
+    }
 }
 
 public struct BillSectionData: SectionDataProtocol, Equatable, Identifiable {

--- a/Core/Sources/Core/Mock/MockModels.swift
+++ b/Core/Sources/Core/Mock/MockModels.swift
@@ -123,7 +123,14 @@ extension BillSubCategory {
 
 extension CurrencyModel {
     static func stub() -> CurrencyModel {
-        .init(shortName: modelFaker.name.prefix(), fullName: modelFaker.name.firstName(), rate: modelFaker.number.randomCGFloat(min: 0, max: 2))
+        let modifiedAt = Date().addingTimeInterval(-TimeInterval.random(in: 0...100_000))
+        return .init(
+            recordName: UUID().uuidString,
+            shortName: modelFaker.name.prefix(),
+            fullName: modelFaker.name.firstName(),
+            rate: Double.random(in: 0...2),
+            modifiedAt: modifiedAt
+        )
     }
 }
 

--- a/Core/Sources/Core/Resources/RecordBookData.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Core/Sources/Core/Resources/RecordBookData.xcdatamodeld/Model.xcdatamodel/contents
@@ -37,6 +37,13 @@
         <relationship name="subCategory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BillSubCategoryEntity" inverseName="bills" inverseEntity="BillSubCategoryEntity"/>
         <relationship name="updatedByUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserEntity" inverseName="updatedBills" inverseEntity="UserEntity"/>
     </entity>
+    <entity name="CurrencyEntity" representedClassName="CurrencyEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="recordName" optional="YES" attributeType="String"/>
+        <attribute name="shortName" optional="YES" attributeType="String"/>
+        <attribute name="fullName" optional="YES" attributeType="String"/>
+        <attribute name="rate" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="modifiedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
     <entity name="UserEntity" representedClassName="UserEntity" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -52,6 +59,7 @@
         <memberEntity name="TransactionEntity"/>
         <memberEntity name="BillSubCategoryEntity"/>
         <memberEntity name="UserEntity"/>
+        <memberEntity name="CurrencyEntity"/>
     </configuration>
     <configuration name="Local">
         <memberEntity name="LedgerEntity"/>
@@ -59,5 +67,6 @@
         <memberEntity name="TransactionEntity"/>
         <memberEntity name="BillSubCategoryEntity"/>
         <memberEntity name="UserEntity"/>
+        <memberEntity name="CurrencyEntity"/>
     </configuration>
 </model>

--- a/Feature/Sources/Currency/CurrencyStore.swift
+++ b/Feature/Sources/Currency/CurrencyStore.swift
@@ -15,31 +15,92 @@ public struct CurrencyStore {
     public struct State {
         var currencies: [CurrencyModel]
         var selectedCurrency: CurrencyModel?
+        var isLoading: Bool
 
-        public init(currencies: [CurrencyModel] = .stub(),
-                    selectedCurrency: CurrencyModel? = nil
+        @Presents var alert: AlertState<Action.Alert>?
+
+        public init(currencies: [CurrencyModel] = [],
+                    selectedCurrency: CurrencyModel? = nil,
+                    isLoading: Bool = false
         ) {
             self.currencies = currencies
             self.selectedCurrency = selectedCurrency
+            self.isLoading = isLoading
         }
     }
 
     public enum Action {
         case onAppear
         case onTap(CurrencyModel)
+        case localCurrenciesResponse([CurrencyModel])
+        case syncResponse(TaskResult<[CurrencyModel]>)
+        case alert(PresentationAction<Alert>)
+
+        public enum Alert: Equatable {
+            case dismiss
+        }
     }
 
     public init() {}
 
+    @Dependency(\.currencyClient) var currencyClient
+
     public var body: some Reducer<State, Action> {
         Reduce { state, action in
+            func applyCurrencies(_ currencies: [CurrencyModel]) {
+                state.currencies = currencies
+                if let selected = state.selectedCurrency,
+                   let matched = currencies.first(where: { $0.recordName == selected.recordName }) {
+                    state.selectedCurrency = matched
+                } else if state.selectedCurrency == nil {
+                    state.selectedCurrency = currencies.first
+                }
+            }
+
             switch action {
             case .onAppear:
+                guard !state.isLoading else { return .none }
+                state.isLoading = true
+                return .run { send in
+                    let local = await currencyClient.fetchLocalCurrencies()
+                    await send(.localCurrenciesResponse(local))
+
+                    do {
+                        let remote = try await currencyClient.syncFromCloud()
+                        await send(.syncResponse(.success(remote)))
+                    } catch {
+                        await send(.syncResponse(.failure(error)))
+                    }
+                }
+            case let .localCurrenciesResponse(currencies):
+                applyCurrencies(currencies)
+                return .none
+            case let .syncResponse(.success(currencies)):
+                state.isLoading = false
+                applyCurrencies(currencies)
+                return .none
+            case let .syncResponse(.failure(error)):
+                state.isLoading = false
+                state.alert = AlertState {
+                    TextState("同步失败")
+                } actions: {
+                    ButtonState(action: .send(.dismiss)) {
+                        TextState("确定")
+                    }
+                } message: {
+                    TextState(error.localizedDescription)
+                }
                 return .none
             case let .onTap(value):
                 state.selectedCurrency = value
                 return .none
+            case .alert(.dismiss):
+                state.alert = nil
+                return .none
+            case .alert:
+                return .none
             }
         }
+        .ifLet(\.$alert, action: /Action.alert)
     }
 }

--- a/Feature/Sources/Currency/CurrencyView.swift
+++ b/Feature/Sources/Currency/CurrencyView.swift
@@ -28,6 +28,12 @@ public struct CurrencyView: View {
         
         NavigationStack {
             ScrollView {
+                if store.isLoading && store.currencies.isEmpty {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                }
+
                 LazyVGrid(columns: items,
                           alignment: .leading,
                           spacing: 10,
@@ -39,7 +45,7 @@ public struct CurrencyView: View {
                             HStack(spacing: 20) {
                                 Text("\(store.currencies[idx].shortName.firstValue)")
                                     .font(.system(size: 20, weight: .bold))
-                                
+
                                 Text("\(store.currencies[idx].fullName)")
                                     .font(.system(size: 20, weight: .bold))
                                 Spacer()
@@ -48,7 +54,7 @@ public struct CurrencyView: View {
                             .padding()
                             .background(store.selectedCurrency == store.currencies[idx] ? Color.flatGreen : Color.lightGray)
                             .clipShape(RoundedRectangle(cornerRadius: 8))
-                            
+
                         })
                     }
                 })
@@ -68,14 +74,18 @@ public struct CurrencyView: View {
         .onAppear(perform: {
             store.send(.onAppear)
         })
+        .alert(store: store.scope(state: \.$alert, action: \.alert))
     }
 }
 
 
 #Preview {
-    CurrencyView(
-        Store(initialState: CurrencyStore.State(), reducer: {
+    let currencies = [CurrencyModel].stub()
+    return CurrencyView(
+        Store(initialState: CurrencyStore.State(currencies: currencies, selectedCurrency: currencies.first)) {
             CurrencyStore()
-        })
+        } withDependencies: {
+            $0.currencyClient = .stub
+        }
     )
 }

--- a/Feature/Sources/InputAccounts/InputAccountsStore.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsStore.swift
@@ -326,7 +326,7 @@ public struct InputAccountsStore {
  
 extension InputAccountsStore {
     struct Constants {
-        static let usdCurrency = CurrencyModel(shortName: "USD", fullName: "United States Dollar", rate: 1)
+        static let usdCurrency = CurrencyModel.usd
         static let placeholderLedger = AccountBook(
             owner: .init(id: "", name: ""),
             participacer: [],


### PR DESCRIPTION
## Summary
- add a CloudKit-enabled `CurrencyEntity` to the Core Data model and register it in both local and cloud configurations
- provide `CurrencyModel` conversions and a `CurrencyDataClient` for fetching cached currencies and syncing records from the public CloudKit database with deduplication and cleanup of stale entities
- update the currency feature to consume the new client, surface loading/errors, and keep previews seeded via the stub dependency

## Testing
- Not run (Xcode project without command-line test configuration)


------
https://chatgpt.com/codex/tasks/task_e_68cbce9f9448832eaac36532f31af133