### PR TITLE
Implement CloudKit bill category management

### DIFF
--- a/Core/Sources/Core/BillCategoryService.swift
+++ b/Core/Sources/Core/BillCategoryService.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+#if canImport(CloudKit)
+import CloudKit
+
+public enum BillCategoryServiceError: Error {
+    case unknown
+    case cloudKit(Error)
+}
+
+extension BillCategoryServiceError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unknown:
+            return "发生未知错误"
+        case let .cloudKit(error):
+            return error.localizedDescription
+        }
+    }
+}
+
+public final class BillCategoryService {
+    private enum RecordType {
+        static let mainCategory = "BillMainCategory"
+        static let subCategory = "BillSubCategory"
+    }
+
+    private enum Field {
+        static let name = "name"
+        static let mainCategoryReference = "mainCategory"
+        static let mainCategoryIdentifier = "mainCategoryId"
+    }
+
+    private let container: CKContainer
+    private let publicDatabase: CKDatabase
+    private let privateDatabase: CKDatabase
+
+    public init(container: CKContainer = CKContainer(identifier: Config.containerIdentifier)) {
+        self.container = container
+        self.publicDatabase = container.publicCloudDatabase
+        self.privateDatabase = container.privateCloudDatabase
+    }
+
+    // MARK: - Fetch
+
+    /// Fetches all bill categories from the public database.
+    /// - Returns: A list of main categories containing their associated sub categories.
+    public func fetchPublicCategories() async throws -> [BillMainCategoryModel] {
+        try await fetchCategories(in: publicDatabase, scope: .public)
+    }
+
+    /// Fetches all bill categories from the user's private database.
+    public func fetchPrivateCategories() async throws -> [BillMainCategoryModel] {
+        try await fetchCategories(in: privateDatabase, scope: .private)
+    }
+
+    /// Fetches categories from both public and private databases.
+    public func fetchAllCategories() async throws -> [BillMainCategoryModel] {
+        async let publicCategories = fetchPublicCategories()
+        async let privateCategories = fetchPrivateCategories()
+        return try await publicCategories + privateCategories
+    }
+
+    // MARK: - Create
+
+    /// Creates a new private main category.
+    @discardableResult
+    public func createPrivateMainCategory(name: String) async throws -> BillMainCategoryModel {
+        let record = CKRecord(recordType: RecordType.mainCategory)
+        record[Field.name] = name as NSString
+
+        let savedRecord = try await save(record: record, in: privateDatabase)
+        return BillMainCategoryModel(
+            id: savedRecord.recordID.recordName,
+            name: name,
+            subCategories: [],
+            scope: .private
+        )
+    }
+
+    /// Creates a new private sub category for the provided main category.
+    @discardableResult
+    public func createPrivateSubCategory(name: String, mainCategoryID: String) async throws -> BillSubCategoryModel {
+        let record = CKRecord(recordType: RecordType.subCategory)
+        record[Field.name] = name as NSString
+        record[Field.mainCategoryIdentifier] = mainCategoryID as NSString
+
+        let savedRecord = try await save(record: record, in: privateDatabase)
+        return BillSubCategoryModel(
+            id: savedRecord.recordID.recordName,
+            name: name,
+            mainCategoryID: mainCategoryID,
+            scope: .private
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func fetchCategories(in database: CKDatabase, scope: BillCategoryScope) async throws -> [BillMainCategoryModel] {
+        let mainRecords = try await fetchRecords(in: database, recordType: RecordType.mainCategory)
+        let subRecords = try await fetchRecords(in: database, recordType: RecordType.subCategory)
+
+        let subModels = subRecords.map { record -> BillSubCategoryModel in
+            let mainCategoryIdentifier: String?
+
+            if let reference = record[Field.mainCategoryReference] as? CKRecord.Reference {
+                mainCategoryIdentifier = reference.recordID.recordName
+            } else if let identifier = record[Field.mainCategoryIdentifier] as? String {
+                mainCategoryIdentifier = identifier
+            } else {
+                mainCategoryIdentifier = nil
+            }
+
+            let name = (record[Field.name] as? String) ?? ""
+            return BillSubCategoryModel(
+                id: record.recordID.recordName,
+                name: name,
+                mainCategoryID: mainCategoryIdentifier,
+                scope: scope
+            )
+        }
+
+        let subCategoryDictionary = Dictionary(grouping: subModels, by: { $0.mainCategoryID ?? "" })
+
+        return mainRecords.map { record in
+            let identifier = record.recordID.recordName
+            let name = (record[Field.name] as? String) ?? ""
+            let relatedSubCategories = subCategoryDictionary[identifier] ?? []
+
+            return BillMainCategoryModel(
+                id: identifier,
+                name: name,
+                subCategories: relatedSubCategories,
+                scope: scope
+            )
+        }
+    }
+
+    private func fetchRecords(in database: CKDatabase, recordType: String) async throws -> [CKRecord] {
+        try await withCheckedThrowingContinuation { continuation in
+            var fetchedRecords: [CKRecord] = []
+            var isFinished = false
+
+            func fetch(cursor: CKQueryOperation.Cursor?) {
+                let operation: CKQueryOperation
+                if let cursor = cursor {
+                    operation = CKQueryOperation(cursor: cursor)
+                } else {
+                    let predicate = NSPredicate(value: true)
+                    let query = CKQuery(recordType: recordType, predicate: predicate)
+                    operation = CKQueryOperation(query: query)
+                }
+
+                operation.recordFetchedBlock = { record in
+                    fetchedRecords.append(record)
+                }
+
+                operation.queryCompletionBlock = { cursor, error in
+                    if isFinished {
+                        return
+                    }
+
+                    if let error = error {
+                        isFinished = true
+                        continuation.resume(throwing: BillCategoryServiceError.cloudKit(error))
+                        return
+                    }
+
+                    guard let cursor = cursor else {
+                        isFinished = true
+                        continuation.resume(returning: fetchedRecords)
+                        return
+                    }
+
+                    fetch(cursor: cursor)
+                }
+
+                database.add(operation)
+            }
+
+            fetch(cursor: nil)
+        }
+    }
+
+    private func save(record: CKRecord, in database: CKDatabase) async throws -> CKRecord {
+        try await withCheckedThrowingContinuation { continuation in
+            database.save(record) { savedRecord, error in
+                if let error = error {
+                    continuation.resume(throwing: BillCategoryServiceError.cloudKit(error))
+                    return
+                }
+
+                guard let savedRecord = savedRecord else {
+                    continuation.resume(throwing: BillCategoryServiceError.unknown)
+                    return
+                }
+
+                continuation.resume(returning: savedRecord)
+            }
+        }
+    }
+}
+
+#else
+
+public enum BillCategoryServiceError: Error {
+    case unavailable
+}
+
+extension BillCategoryServiceError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "当前平台不支持账单分类服务"
+        }
+    }
+}
+
+public final class BillCategoryService {
+    public init(container: Any? = nil) {}
+
+    public func fetchPublicCategories() async throws -> [BillMainCategoryModel] {
+        throw BillCategoryServiceError.unavailable
+    }
+
+    public func fetchPrivateCategories() async throws -> [BillMainCategoryModel] {
+        throw BillCategoryServiceError.unavailable
+    }
+
+    public func fetchAllCategories() async throws -> [BillMainCategoryModel] {
+        throw BillCategoryServiceError.unavailable
+    }
+
+    @discardableResult
+    public func createPrivateMainCategory(name: String) async throws -> BillMainCategoryModel {
+        throw BillCategoryServiceError.unavailable
+    }
+
+    @discardableResult
+    public func createPrivateSubCategory(name: String, mainCategoryID: String) async throws -> BillSubCategoryModel {
+        throw BillCategoryServiceError.unavailable
+    }
+}
+
+#endif

--- a/Core/Sources/Core/Mock/MockModels.swift
+++ b/Core/Sources/Core/Mock/MockModels.swift
@@ -87,14 +87,18 @@ extension BillMainCategoryModel {
                 .stub(),
                 .stub(),
                 .stub()
-            ])
+            ],
+            scope: .public)
     }
 }
 
 extension BillSubCategoryModel {
     static func stub() -> BillSubCategoryModel {
-        .init(id: modelFaker.number.increasingUniqueId().stringValue,
-              name: modelFaker.name.title()
+        .init(
+            id: modelFaker.number.increasingUniqueId().stringValue,
+            name: modelFaker.name.title(),
+            mainCategoryID: modelFaker.number.increasingUniqueId().stringValue,
+            scope: .public
         )
     }
 }

--- a/Core/Sources/Core/Models.swift
+++ b/Core/Sources/Core/Models.swift
@@ -114,15 +114,27 @@ public struct BillModel: Equatable, Identifiable {
 ///
 /// Record:
 /// public
+public enum BillCategoryScope: Equatable {
+    case `public`
+    case `private`
+}
+
 public struct BillMainCategoryModel: Equatable, Identifiable {
     public let id: String
     public let name: String
     public let subCategories: [BillSubCategoryModel]
-    
-    public init(id: String, name: String, subCategories: [BillSubCategoryModel]) {
+    public let scope: BillCategoryScope
+
+    public init(
+        id: String,
+        name: String,
+        subCategories: [BillSubCategoryModel],
+        scope: BillCategoryScope = .public
+    ) {
         self.id = id
         self.name = name
         self.subCategories = subCategories
+        self.scope = scope
     }
 }
 
@@ -137,10 +149,19 @@ public struct BillMainCategoryModel: Equatable, Identifiable {
 public struct BillSubCategoryModel: BillSubCategory, Equatable {
     public let id: String
     public let name: String
-    
-    public init(id: String, name: String) {
+    public let mainCategoryID: String?
+    public let scope: BillCategoryScope
+
+    public init(
+        id: String,
+        name: String,
+        mainCategoryID: String? = nil,
+        scope: BillCategoryScope = .public
+    ) {
         self.id = id
         self.name = name
+        self.mainCategoryID = mainCategoryID
+        self.scope = scope
     }
 }
 

--- a/Feature/Sources/Setting/CategorySelection/CategorySelectionStore.swift
+++ b/Feature/Sources/Setting/CategorySelection/CategorySelectionStore.swift
@@ -1,0 +1,192 @@
+import ComposableArchitecture
+import Core
+
+public struct CategorySelectionStore: Reducer {
+    public struct State: Equatable {
+        public var categories: [BillMainCategoryModel]
+        public var isLoading: Bool
+        public var errorMessage: String?
+        public var newMainCategoryName: String
+        public var selectedMainCategoryID: String?
+        public var newSubCategoryName: String
+
+        public init(
+            categories: [BillMainCategoryModel] = [],
+            isLoading: Bool = false,
+            errorMessage: String? = nil,
+            newMainCategoryName: String = "",
+            selectedMainCategoryID: String? = nil,
+            newSubCategoryName: String = ""
+        ) {
+            self.categories = categories
+            self.isLoading = isLoading
+            self.errorMessage = errorMessage
+            self.newMainCategoryName = newMainCategoryName
+            self.selectedMainCategoryID = selectedMainCategoryID
+            self.newSubCategoryName = newSubCategoryName
+        }
+    }
+
+    public enum Action {
+        case onAppear
+        case refresh
+        case categoriesResponse(TaskResult<[BillMainCategoryModel]>)
+        case setNewMainCategoryName(String)
+        case setNewSubCategoryName(String)
+        case selectMainCategory(String?)
+        case createMainCategory
+        case createMainCategoryResponse(TaskResult<BillMainCategoryModel>)
+        case createSubCategory
+        case createSubCategoryResponse(String, TaskResult<BillSubCategoryModel>)
+        case clearError
+    }
+
+    private let service: BillCategoryService
+
+    public init(service: BillCategoryService = BillCategoryService()) {
+        self.service = service
+    }
+
+    public var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear, .refresh:
+                state.isLoading = true
+                state.errorMessage = nil
+                return .run { [service] send in
+                    await send(.categoriesResponse(TaskResult {
+                        try await service.fetchAllCategories()
+                    }))
+                }
+
+            case let .categoriesResponse(.success(categories)):
+                state.isLoading = false
+                state.categories = categories.sorted(by: { lhs, rhs in
+                    switch (lhs.scope, rhs.scope) {
+                    case (.public, .private):
+                        return true
+                    case (.private, .public):
+                        return false
+                    default:
+                        return lhs.name.localizedCompare(rhs.name) == .orderedAscending
+                    }
+                })
+                state.errorMessage = nil
+                return .none
+
+            case let .categoriesResponse(.failure(error)):
+                state.isLoading = false
+                state.errorMessage = error.localizedDescription
+                return .none
+
+            case let .setNewMainCategoryName(text):
+                state.newMainCategoryName = text
+                return .none
+
+            case let .setNewSubCategoryName(text):
+                state.newSubCategoryName = text
+                return .none
+
+            case let .selectMainCategory(identifier):
+                state.selectedMainCategoryID = identifier
+                return .none
+
+            case .createMainCategory:
+                let trimmed = state.newMainCategoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else {
+                    state.errorMessage = "请输入大分类名称"
+                    return .none
+                }
+
+                state.isLoading = true
+                state.errorMessage = nil
+                state.newMainCategoryName = ""
+
+                return .run { [service] send in
+                    await send(.createMainCategoryResponse(TaskResult {
+                        try await service.createPrivateMainCategory(name: trimmed)
+                    }))
+                }
+
+            case let .createMainCategoryResponse(.success(category)):
+                state.isLoading = false
+                state.errorMessage = nil
+                state.categories.append(category)
+                state.categories.sort(by: { lhs, rhs in
+                    switch (lhs.scope, rhs.scope) {
+                    case (.public, .private):
+                        return true
+                    case (.private, .public):
+                        return false
+                    default:
+                        return lhs.name.localizedCompare(rhs.name) == .orderedAscending
+                    }
+                })
+                return .none
+
+            case let .createMainCategoryResponse(.failure(error)):
+                state.isLoading = false
+                state.errorMessage = error.localizedDescription
+                return .none
+
+            case .createSubCategory:
+                guard let parentID = state.selectedMainCategoryID else {
+                    state.errorMessage = "请选择所属的大分类"
+                    return .none
+                }
+
+                let trimmed = state.newSubCategoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else {
+                    state.errorMessage = "请输入小分类名称"
+                    return .none
+                }
+
+                state.isLoading = true
+                state.errorMessage = nil
+                state.newSubCategoryName = ""
+
+                return .run { [service] send in
+                    await send(.createSubCategoryResponse(parentID, TaskResult {
+                        try await service.createPrivateSubCategory(name: trimmed, mainCategoryID: parentID)
+                    }))
+                }
+
+            case let .createSubCategoryResponse(parentID, .success(subCategory)):
+                state.isLoading = false
+                state.errorMessage = nil
+
+                if let index = state.categories.firstIndex(where: { $0.id == parentID }) {
+                    let category = state.categories[index]
+                    var subCategories = category.subCategories
+                    subCategories.append(subCategory)
+                    subCategories.sort(by: { $0.name.localizedCompare($1.name) == .orderedAscending })
+                    state.categories[index] = BillMainCategoryModel(
+                        id: category.id,
+                        name: category.name,
+                        subCategories: subCategories,
+                        scope: category.scope
+                    )
+                } else {
+                    state.categories.append(
+                        BillMainCategoryModel(
+                            id: parentID,
+                            name: parentID,
+                            subCategories: [subCategory],
+                            scope: .private
+                        )
+                    )
+                }
+                return .none
+
+            case let .createSubCategoryResponse(_, .failure(error)):
+                state.isLoading = false
+                state.errorMessage = error.localizedDescription
+                return .none
+
+            case .clearError:
+                state.errorMessage = nil
+                return .none
+            }
+        }
+    }
+}

--- a/Feature/Sources/Setting/CategorySelection/CategorySelectionView.swift
+++ b/Feature/Sources/Setting/CategorySelection/CategorySelectionView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+import ComposableArchitecture
+import Core
+
+public struct CategorySelectionView: View {
+    let store: StoreOf<CategorySelectionStore>
+
+    public init(store: StoreOf<CategorySelectionStore>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            List {
+                if let message = viewStore.errorMessage {
+                    Section {
+                        Text(message)
+                            .foregroundColor(.red)
+                            .font(.footnote)
+                            .onTapGesture {
+                                viewStore.send(.clearError)
+                            }
+                    }
+                }
+
+                Section(header: Text("新增大分类")) {
+                    TextField(
+                        "请输入大分类名称",
+                        text: viewStore.binding(
+                            get: \.newMainCategoryName,
+                            send: CategorySelectionStore.Action.setNewMainCategoryName
+                        )
+                    )
+                    .textInputAutocapitalization(.none)
+
+                    Button("创建大分类") {
+                        viewStore.send(.createMainCategory)
+                    }
+                    .disabled(viewStore.newMainCategoryName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || viewStore.isLoading)
+                }
+
+                Section(header: Text("新增小分类")) {
+                    Picker(
+                        "所属大分类",
+                        selection: viewStore.binding(
+                            get: \.selectedMainCategoryID,
+                            send: CategorySelectionStore.Action.selectMainCategory
+                        )
+                    ) {
+                        Text("未选择").tag(nil as String?)
+                        ForEach(viewStore.categories, id: \.id) { category in
+                            Text(category.name)
+                                .tag(category.id as String?)
+                        }
+                    }
+
+                    TextField(
+                        "请输入小分类名称",
+                        text: viewStore.binding(
+                            get: \.newSubCategoryName,
+                            send: CategorySelectionStore.Action.setNewSubCategoryName
+                        )
+                    )
+                    .textInputAutocapitalization(.none)
+
+                    Button("创建小分类") {
+                        viewStore.send(.createSubCategory)
+                    }
+                    .disabled(
+                        viewStore.selectedMainCategoryID == nil ||
+                        viewStore.newSubCategoryName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                        viewStore.isLoading
+                    )
+                }
+
+                ForEach(viewStore.categories, id: \.id) { category in
+                    Section(
+                        header: HStack {
+                            Text(category.name)
+                            Spacer()
+                            Text(category.scope == .public ? "公共" : "私人")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    ) {
+                        if category.subCategories.isEmpty {
+                            Text("暂无小分类")
+                                .foregroundColor(.secondary)
+                        } else {
+                            ForEach(category.subCategories, id: \.id) { subCategory in
+                                HStack {
+                                    Text(subCategory.name)
+                                    Spacer()
+                                    Text(subCategory.scope == .public ? "公共" : "私人")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("账单分类")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if viewStore.isLoading {
+                        ProgressView()
+                    } else {
+                        Button(action: { viewStore.send(.refresh) }) {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                    }
+                }
+            }
+            .onAppear {
+                viewStore.send(.onAppear)
+            }
+        }
+    }
+}
+
+struct CategorySelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            CategorySelectionView(
+                store: Store(
+                    initialState: CategorySelectionStore.State(
+                        categories: [
+                            BillMainCategoryModel(
+                                id: "1",
+                                name: "餐饮",
+                                subCategories: [
+                                    BillSubCategoryModel(id: "1-1", name: "早餐", mainCategoryID: "1", scope: .public),
+                                    BillSubCategoryModel(id: "1-2", name: "午餐", mainCategoryID: "1", scope: .public)
+                                ],
+                                scope: .public
+                            ),
+                            BillMainCategoryModel(
+                                id: "2",
+                                name: "自定义",
+                                subCategories: [
+                                    BillSubCategoryModel(id: "2-1", name: "兴趣", mainCategoryID: "2", scope: .private)
+                                ],
+                                scope: .private
+                            )
+                        ]
+                    ),
+                    reducer: {
+                        CategorySelectionStore()
+                    }
+                )
+            )
+        }
+    }
+}

--- a/Feature/Sources/Setting/SettingView.swift
+++ b/Feature/Sources/Setting/SettingView.swift
@@ -17,19 +17,35 @@ public struct SettingView: View {
     }
     public var body: some View {
         WithViewStore(store) { viewStore in
-            VStack {
-                HStack {
-                    Text("当前账本")
-                    Spacer()
-                    Button {
-                        viewStore.send(.tapBook)
-                    } label: {
-                        Text(viewStore.state.bookState.text)
+            NavigationView {
+                List {
+                    Section(header: Text("当前账本")) {
+                        HStack {
+                            Text("当前账本")
+                            Spacer()
+                            Button {
+                                viewStore.send(.tapBook)
+                            } label: {
+                                Text(viewStore.state.bookState.text)
+                            }
+                        }
+                    }
+
+                    Section(header: Text("账单")) {
+                        NavigationLink("账单分类") {
+                            CategorySelectionView(
+                                store: Store(
+                                    initialState: CategorySelectionStore.State(),
+                                    reducer: {
+                                        CategorySelectionStore()
+                                    }
+                                )
+                            )
+                        }
                     }
                 }
-                Spacer()
+                .navigationTitle("设置")
             }
-            .padding()
             .onAppear {
                 viewStore.send(.onAppear)
             }


### PR DESCRIPTION
## Summary
- add a CloudKit-backed bill category service that fetches public data, merges private categories, and supports creating personal categories
- extend bill category models with scope metadata and link sub-categories to their parent
- create a category selection store and view and hook it into settings for managing public and private categories

## Testing
- swift test --package-path Core *(fails: unable to clone https://github.com/pointfreeco/swift-composable-architecture due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdf00b500832e883bb2006ac00d73