### PR TITLE
Disable subcategory interactions without main category

### DIFF
--- a/Feature/Sources/InputAccounts/InputAccountsStore.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsStore.swift
@@ -140,6 +140,7 @@ public struct InputAccountsStore {
                 )
                 return .none
             case .tapSubCategory(let category):
+                guard state.selectedMainCategory != nil else { return .none }
                 let selected = category ?? state.selectedSubCategory
                 let subCategories = state.selectedMainCategory?.subCategories ?? []
                 state.destination = .selectSubCategory(

--- a/Feature/Sources/InputAccounts/InputAccountsView.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsView.swift
@@ -59,6 +59,10 @@ public struct InputAccountsView: View {
         .alert($store.scope(state: \.alert, action: \.alert))
     }
 
+    private var isSubCategoryDisabled: Bool {
+        store.selectedMainCategory == nil
+    }
+
     var scrollView: some View {
         ScrollView {
             VStack(spacing: 15) {
@@ -165,9 +169,15 @@ public struct InputAccountsView: View {
                             }
                         }
                         .frame(width: 200, height: 65)
-                        .background(Color.lightGray)
-                        .foregroundStyle(Color.black)
+                        .background(Color.lightGray.opacity(isSubCategoryDisabled ? 0.6 : 1))
+                        .foregroundStyle(isSubCategoryDisabled ? Color.gray : Color.black)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(isSubCategoryDisabled ? Color.gray.opacity(0.5) : Color.clear, lineWidth: 1)
+                        )
+                        .opacity(isSubCategoryDisabled ? 0.6 : 1)
+                        .disabled(isSubCategoryDisabled)
                         Spacer()
                     }
                 }


### PR DESCRIPTION
## Summary
- disable the subcategory selector until a main category is chosen in the input accounts view
- prevent the tapSubCategory reducer branch from triggering without a selected main category

## Testing
- ⚠️ `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1fe23760832eadfc41dfc2565dfc