### PR TITLE
Add photo selection support in InputAccounts

### DIFF
--- a/Feature/Sources/InputAccounts/InputAccountsStore.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsStore.swift
@@ -27,7 +27,9 @@ public struct InputAccountsStore {
         var tapPlus: Bool
         var billsType: [BillType]
         var selectedBillType: BillType
-        var showPhotoLib = false
+        var selectedImageData: Data?
+        var isCameraPickerPresented = false
+        var isPhotoLibraryPresented = false
         var ledger: AccountBook
         var selectedCurrency: CurrencyModel
         var selectedMainCategory: BillMainCategory?
@@ -53,7 +55,10 @@ public struct InputAccountsStore {
                     selectedMainCategory: BillMainCategory? = nil,
                     selectedSubCategory: BillSubCategory? = nil,
                     memo: String = "",
-                    isSaving: Bool = false
+                    isSaving: Bool = false,
+                    selectedImageData: Data? = nil,
+                    isCameraPickerPresented: Bool = false,
+                    isPhotoLibraryPresented: Bool = false
         ) {
             if title.isEmpty {
                 self.title = selectedBillType == .income ? "Income" : "Payment"
@@ -72,6 +77,9 @@ public struct InputAccountsStore {
             self.selectedSubCategory = selectedSubCategory
             self.memo = memo
             self.isSaving = isSaving
+            self.selectedImageData = selectedImageData
+            self.isCameraPickerPresented = isCameraPickerPresented
+            self.isPhotoLibraryPresented = isPhotoLibraryPresented
         }
     }
 
@@ -99,6 +107,9 @@ public struct InputAccountsStore {
         case destination(PresentationAction<Destination.Action>)
         case tapChoosePhoto
         case choosePhotoDialog(PresentationAction<ChoosePhotoDialog>)
+        case presentImagePicker(ImageSource)
+        case imagePicked(Data)
+        case removeImage
         case tapRecord
         case saveResponse(Result<Bill, Error>)
         case alert(PresentationAction<Alert>)
@@ -106,6 +117,10 @@ public struct InputAccountsStore {
         public enum ChoosePhotoDialog: Equatable {
             case fromCamera
             case fromLibrary
+        }
+        public enum ImageSource: Equatable {
+            case camera
+            case photoLibrary
         }
         public enum Alert: Equatable {
             case acknowledge
@@ -175,13 +190,45 @@ public struct InputAccountsStore {
                 })
                 return .none
             case .choosePhotoDialog(.presented(.fromCamera)):
-                // TODO:
-                // present imagepicker
-                return .none
+                return .send(.presentImagePicker(.camera))
             case .choosePhotoDialog(.presented(.fromLibrary)):
-                // TODO:
-                // present photo picker
-                state.showPhotoLib = true
+                return .send(.presentImagePicker(.photoLibrary))
+            case .presentImagePicker(.camera):
+                state.isCameraPickerPresented = true
+                state.destination = .fromCamera(
+                    .init(source: .camera)
+                )
+                return .none
+            case .presentImagePicker(.photoLibrary):
+                state.isPhotoLibraryPresented = true
+                state.destination = .fromLibrary(
+                    .init(source: .photoLibrary)
+                )
+                return .none
+            case let .destination(.presented(.fromCamera(.didFinishPicking(data)))):
+                return .send(.imagePicked(data))
+            case .destination(.presented(.fromCamera(.didCancel))):
+                state.isCameraPickerPresented = false
+                state.destination = nil
+                return .none
+            case let .destination(.presented(.fromLibrary(.didFinishPicking(data)))):
+                return .send(.imagePicked(data))
+            case .destination(.presented(.fromLibrary(.didCancel))):
+                state.isPhotoLibraryPresented = false
+                state.destination = nil
+                return .none
+            case .destination(.dismiss):
+                state.isCameraPickerPresented = false
+                state.isPhotoLibraryPresented = false
+                return .none
+            case let .imagePicked(data):
+                state.selectedImageData = data
+                state.isCameraPickerPresented = false
+                state.isPhotoLibraryPresented = false
+                state.destination = nil
+                return .none
+            case .removeImage:
+                state.selectedImageData = nil
                 return .none
             case .input(let value):
                 switch value {
@@ -320,8 +367,40 @@ public struct InputAccountsStore {
         case selectCategory(CategoriesStore)
         case selectSubCategory(SubCategoriesStore)
         case selectCurrency(CurrencyStore)
-        case fromCamera
-        case fromLibrary
+        case fromCamera(ImagePicker)
+        case fromLibrary(ImagePicker)
+    }
+}
+
+extension InputAccountsStore.Destination {
+    @Reducer
+    public struct ImagePicker {
+        @ObservableState
+        public struct State: Equatable, Identifiable {
+            public let id: UUID
+            public let source: Source
+
+            public init(id: UUID = UUID(), source: Source) {
+                self.id = id
+                self.source = source
+            }
+        }
+
+        public enum Source: Equatable {
+            case camera
+            case photoLibrary
+        }
+
+        public enum Action: Equatable {
+            case didFinishPicking(Data)
+            case didCancel
+        }
+
+        public var body: some ReducerOf<Self> {
+            Reduce { _, _ in
+                .none
+            }
+        }
     }
 }
  

--- a/Feature/Sources/InputAccounts/InputAccountsView.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsView.swift
@@ -8,6 +8,7 @@
 import ComposableArchitecture
 import Foundation
 import SwiftUI
+import UIKit
 import UIComponents
 import Categories
 import SubCategories
@@ -57,6 +58,32 @@ public struct InputAccountsView: View {
         })
         .confirmationDialog($store.scope(state: \.choosePhotoDialog, action: \.choosePhotoDialog))
         .alert($store.scope(state: \.alert, action: \.alert))
+        .sheet(
+            item: $store.scope(state: \.destination?.fromCamera, action: \.destination.fromCamera)
+        ) { store in
+            ImagePickerContainer(
+                source: .camera,
+                onImagePicked: { data in
+                    store.send(.didFinishPicking(data))
+                },
+                onCancel: {
+                    store.send(.didCancel)
+                }
+            )
+        }
+        .sheet(
+            item: $store.scope(state: \.destination?.fromLibrary, action: \.destination.fromLibrary)
+        ) { store in
+            ImagePickerContainer(
+                source: .photoLibrary,
+                onImagePicked: { data in
+                    store.send(.didFinishPicking(data))
+                },
+                onCancel: {
+                    store.send(.didCancel)
+                }
+            )
+        }
     }
 
     private var isSubCategoryDisabled: Bool {
@@ -191,26 +218,7 @@ public struct InputAccountsView: View {
                 }
                 // photoes
                 Group {
-                    HStack {
-                        Button {
-                            store.send(.tapChoosePhoto)
-                        } label: {
-                            VStack {
-                                HStack(alignment: .center) {
-                                    Text("写真")
-                                        .font(.system(size: 20))
-                                    Spacer()
-                                }
-                                Spacer()
-                            }
-                            .padding(.leading, 15)
-                            .padding(.top, 15)
-                        }
-                        .frame(height: 150)
-                        .background(Color.lightGray)
-                        .foregroundStyle(Color.black)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                    }
+                    photoSection
                 }
                 
                 // submit buttons
@@ -241,6 +249,113 @@ public struct InputAccountsView: View {
         }
     }
     
+}
+
+private extension InputAccountsView {
+    var photoSection: some View {
+        ZStack(alignment: .topTrailing) {
+            Button {
+                store.send(.tapChoosePhoto)
+            } label: {
+                ZStack {
+                    if let image = imageFromData(store.selectedImageData) {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 150)
+                            .clipped()
+                    } else {
+                        VStack {
+                            HStack(alignment: .center) {
+                                Text("写真")
+                                    .font(.system(size: 20))
+                                Spacer()
+                            }
+                            Spacer()
+                        }
+                        .padding(.leading, 15)
+                        .padding(.top, 15)
+                    }
+                }
+            }
+            .frame(height: 150)
+            .background(Color.lightGray)
+            .foregroundStyle(Color.black)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            if store.selectedImageData != nil {
+                Button {
+                    store.send(.removeImage)
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(Color.white)
+                        .padding(8)
+                        .background(Color.black.opacity(0.6))
+                        .clipShape(Circle())
+                }
+                .padding(8)
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    func imageFromData(_ data: Data?) -> Image? {
+        guard
+            let data,
+            let uiImage = UIImage(data: data)
+        else {
+            return nil
+        }
+        return Image(uiImage: uiImage)
+    }
+}
+
+private struct ImagePickerContainer: UIViewControllerRepresentable {
+    let source: UIImagePickerController.SourceType
+    let onImagePicked: (Data) -> Void
+    let onCancel: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onImagePicked: onImagePicked, onCancel: onCancel)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        picker.sourceType = source
+        picker.allowsEditing = false
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let onImagePicked: (Data) -> Void
+        let onCancel: () -> Void
+
+        init(onImagePicked: @escaping (Data) -> Void, onCancel: @escaping () -> Void) {
+            self.onImagePicked = onImagePicked
+            self.onCancel = onCancel
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            if let image = info[.originalImage] as? UIImage,
+               let data = image.jpegData(compressionQuality: 0.8)
+            {
+                onImagePicked(data)
+            }
+            picker.dismiss(animated: true)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            onCancel()
+            picker.dismiss(animated: true)
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- add state and actions to store selected receipt photos and present camera/photo pickers
- integrate picker destinations that surface camera or library UIs and record selections
- render the chosen image in the input view with a delete control to remove it

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc2312490c832e90c3691c28a0b41f