### PR TITLE
Fetch categories data on appear

### DIFF
--- a/Feature/Sources/Categories/CategoriesStore.swift
+++ b/Feature/Sources/Categories/CategoriesStore.swift
@@ -16,7 +16,7 @@ public struct CategoriesStore {
         var categories: [BillMainCategory]
         var selectedCategory: BillMainCategory?
 
-        public init(categories: [BillMainCategory] = .stub(), 
+        public init(categories: [BillMainCategory] = [],
                     selectedCategory: BillMainCategory? = nil
         ) {
             self.categories = categories
@@ -27,6 +27,7 @@ public struct CategoriesStore {
     public enum Action {
         case onAppear
         case onTap(BillMainCategory)
+        case categoriesResponse(TaskResult<[BillMainCategory]>)
     }
 
     public init() {}
@@ -37,9 +38,23 @@ public struct CategoriesStore {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                return .none
+                return .run { [billCategoryClient] send in
+                    await send(.categoriesResponse(TaskResult {
+                        try await billCategoryClient.fetchAllCategories()
+                    }))
+                }
             case let .onTap(category):
                 state.selectedCategory = category
+                return .none
+            case let .categoriesResponse(.success(categories)):
+                state.categories = categories
+                if let selectedID = state.selectedCategory?.id {
+                    state.selectedCategory = categories.first(where: { $0.id == selectedID })
+                }
+                return .none
+            case .categoriesResponse(.failure):
+                state.categories = []
+                state.selectedCategory = nil
                 return .none
             }
         }

--- a/Feature/Sources/Categories/CategoriesView.swift
+++ b/Feature/Sources/Categories/CategoriesView.swift
@@ -76,7 +76,7 @@ public struct CategoriesView: View {
 
 #Preview {
     CategoriesView(
-        Store(initialState: CategoriesStore.State(), reducer: {
+        Store(initialState: CategoriesStore.State(categories: .stub()), reducer: {
             CategoriesStore()
         })
     )


### PR DESCRIPTION
## Summary
- trigger a categories fetch when the screen appears and handle the asynchronous response
- clear categories and selection on failure while restoring the selected item on success
- provide stubbed data in the preview now that the default state starts empty

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc1fcceb2c832eafc95e7398773655