### PR TITLE
Refresh bills after saving from add accounts

### DIFF
--- a/Feature/Sources/Billslist/BillslistStore.swift
+++ b/Feature/Sources/Billslist/BillslistStore.swift
@@ -73,6 +73,21 @@ public struct BillslistStore {
                     )
                 )
                 return .none
+            case .destination(.presented(.addAccounts(.saveResponse(.success)))):
+                guard
+                    case .addAccounts(let addAccountsState) = state.destination,
+                    addAccountsState.isSaving == false
+                else {
+                    return .none
+                }
+                state.destination = nil
+                return .run { send in
+                    let ledgers = await ledgerClient.fetchLedgers()
+                    await send(.ledgersResponse(ledgers))
+                }
+            case .destination(.dismiss):
+                state.destination = nil
+                return .none
             case .ledgersResponse(let ledgers):
                 guard !ledgers.isEmpty else {
                     state.bills = []


### PR DESCRIPTION
## Summary
- refresh the ledger and bill list when the add accounts flow saves successfully
- clear the presented destination when the add accounts flow completes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc232c1dec832eb984332a34f1129e