### PR TITLE
Validate input before recording transactions

### DIFF
--- a/Feature/Sources/InputAccounts/InputAccountsStore.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsStore.swift
@@ -37,6 +37,13 @@ public struct InputAccountsStore {
         var currentOperator: Operator?
         var currentOperand: String?
 
+        var isFormValid: Bool {
+            guard Double(inputValue) != nil else { return false }
+            guard let mainCategory = selectedMainCategory else { return false }
+            guard let subCategory = selectedSubCategory else { return false }
+            return !mainCategory.id.isEmpty && !subCategory.id.isEmpty
+        }
+
         @Presents var destination: Destination.State?
         @Presents var choosePhotoDialog: ConfirmationDialogState<Action.ChoosePhotoDialog>?
         @Presents var alert: AlertState<Action.Alert>?
@@ -230,8 +237,14 @@ public struct InputAccountsStore {
                     state.alert = Self.makeAlert(message: "金額を入力してください。")
                     return .none
                 }
-                let mainCategory = state.selectedMainCategory ?? BillMainCategory(id: UUID().uuidString, name: "未分類", subCategories: [])
-                let subCategory = state.selectedSubCategory ?? BillSubCategory(id: UUID().uuidString, name: "未分類")
+                guard let mainCategory = state.selectedMainCategory else {
+                    state.alert = Self.makeAlert(message: "カテゴリを選択してください。")
+                    return .none
+                }
+                guard let subCategory = state.selectedSubCategory else {
+                    state.alert = Self.makeAlert(message: "サブカテゴリを選択してください。")
+                    return .none
+                }
                 var descriptionText = state.memo
                 let currency = state.selectedCurrency.shortName
                 if !currency.isEmpty {

--- a/Feature/Sources/InputAccounts/InputAccountsView.swift
+++ b/Feature/Sources/InputAccounts/InputAccountsView.swift
@@ -63,6 +63,10 @@ public struct InputAccountsView: View {
         store.selectedMainCategory == nil
     }
 
+    private var isRecordDisabled: Bool {
+        !store.isFormValid || store.isSaving
+    }
+
     var scrollView: some View {
         ScrollView {
             VStack(spacing: 15) {
@@ -231,10 +235,10 @@ public struct InputAccountsView: View {
                         }
                     }
                     .frame(height: 68)
-                    .background(Color.black)
-                    .foregroundStyle(Color.white)
+                    .background(isRecordDisabled ? Color.gray.opacity(0.3) : Color.black)
+                    .foregroundStyle(isRecordDisabled ? Color.white.opacity(0.7) : Color.white)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .disabled(store.isSaving)
+                    .disabled(isRecordDisabled)
 
                 }
             }


### PR DESCRIPTION
## Summary
- add an `isFormValid` computed property that requires a numeric amount and selected categories before saving
- disable the Record button when the form is invalid or saving and adjust its visual state accordingly
- guard against missing categories when recording to prevent fallback values from being submitted

## Testing
- `swift test --package-path Feature` *(fails: network access to dependencies is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc231d5864832ebb73120522c4ba53