### PR TITLE
Connect settings to ledger selection

### DIFF
--- a/Feature/Sources/Billslist/BillslistStore.swift
+++ b/Feature/Sources/Billslist/BillslistStore.swift
@@ -73,6 +73,10 @@ public struct BillslistStore {
                     )
                 )
                 return .none
+            case let .destination(.presented(.setting(.delegate(.didSelectLedger(ledger))))):
+                state.ledger = ledger
+                state.bills = Self.makeBillSections(from: ledger)
+                return .none
             case .ledgersResponse(let ledgers):
                 guard !ledgers.isEmpty else {
                     state.bills = []

--- a/Feature/Sources/Setting/SettingStore.swift
+++ b/Feature/Sources/Setting/SettingStore.swift
@@ -16,13 +16,16 @@ public struct SettingStore {
     @ObservableState
     public struct State {
         var bookState: BookState = .notChoosen
+        var currentLedgerID: String?
 
         @Presents var destination: Destination.State?
 
         public init(
-            bookState: BookState = .notChoosen
+            bookState: BookState = .notChoosen,
+            currentLedgerID: String? = nil
         ) {
             self.bookState = bookState
+            self.currentLedgerID = currentLedgerID
         }
     }
 
@@ -35,8 +38,13 @@ public struct SettingStore {
         case tapBook
         case none
         case onAppear
-//        case selectBook(AccountBooklistStore.Action)
+        case ledgersResponse(savedID: String?, ledgers: [AccountBook])
         case destination(PresentationAction<Destination.Action>)
+        case delegate(DelegateAction)
+    }
+
+    public enum DelegateAction: Equatable {
+        case didSelectLedger(AccountBook)
     }
 
     public enum BookState: Equatable {
@@ -57,6 +65,7 @@ public struct SettingStore {
     }
 
     @Dependency(\.preferences) var preferences
+    @Dependency(\.ledgerClient) var ledgerClient
     // TODO: depedency config
     public init() {}
 
@@ -64,28 +73,41 @@ public struct SettingStore {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                // TODO: find model from local store.
-                if let currentBookId = preferences.value(forKey: "currentBook") as? String {
-                    // check current book id is validate
-                    // find AccountBookModel from bookId
+                let savedID = preferences.value(forKey: "currentBook") as? String
+                state.currentLedgerID = savedID
+                return .run { [savedID] send in
+                    let ledgers = await ledgerClient.fetchLedgers()
+                    await send(.ledgersResponse(savedID: savedID, ledgers: ledgers))
+                }
+            case let .ledgersResponse(savedID, ledgers):
+                if let savedID, let ledger = ledgers.first(where: { $0.id == savedID }) {
+                    state.bookState = .normal(ledger.name)
+                    state.currentLedgerID = ledger.id
                 } else {
                     state.bookState = .notChoosen
+                    state.currentLedgerID = nil
                 }
                 return .none
             case .tapBook:
                 // TODO: check route
                 // Mock:
-                state.destination = .selectBook(.init())
+                state.destination = .selectBook(.init(selected: state.currentLedgerID))
                 return .none
             case .destination(.presented(.selectBook(.selectDone))):
                 switch state.destination {
                 case let .selectBook(bookState):
                     if let value = bookState.selectedBook {
                         state.bookState = .normal(value.name)
+                        state.currentLedgerID = value.id
+                        preferences.set(value.id, forKey: "currentBook")
+                        return .send(.delegate(.didSelectLedger(value)))
                     }
                 default:
                     break
                 }
+                return .none
+
+            case .delegate:
                 return .none
 
             default:


### PR DESCRIPTION
## Summary
- inject the ledger client into `SettingStore` so it loads the saved ledger on appear
- pass the current ledger id into the book picker and persist newly selected ledgers
- let the bills list react to ledger changes surfaced by the settings screen

## Testing
- swift test *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2338ec9c832eb297bd149eabe99d