### PR TITLE
Add read-only support for account book config

### DIFF
--- a/Feature/Sources/AccountBookConfig/AccountBookConfigStore.swift
+++ b/Feature/Sources/AccountBookConfig/AccountBookConfigStore.swift
@@ -19,6 +19,8 @@ public struct AccountBookConfigStore {
 
         public var book: AccountBook?
 
+        public var isEditable: Bool
+
         var paticipators: [Participacer] = []
 
         var originalName: String = ""
@@ -26,7 +28,7 @@ public struct AccountBookConfigStore {
         var isSaving: Bool = false
 
         var saveDisable: Bool {
-            trimmedName.isEmpty || isSaving
+            trimmedName.isEmpty || isSaving || !isEditable
         }
 
         var isCreate: Bool
@@ -40,6 +42,7 @@ public struct AccountBookConfigStore {
         }
 
         var hasEdits: Bool {
+            guard isEditable else { return false }
             if isCreate {
                 return !trimmedName.isEmpty
             }
@@ -50,9 +53,11 @@ public struct AccountBookConfigStore {
         @Presents var alert: AlertState<Action.Alert>?
 
         public init(
-            book: AccountBook? = nil
+            book: AccountBook? = nil,
+            isEditable: Bool = true
         ) {
             self.book = book
+            self.isEditable = isEditable
             self.isCreate = book == nil
             if let book {
                 self.name = book.name
@@ -60,7 +65,7 @@ public struct AccountBookConfigStore {
                 self.paticipators = book.participacer
             }
         }
-        
+
         public static var none = State.init(book: nil)
     }
 
@@ -111,6 +116,9 @@ public struct AccountBookConfigStore {
             case .binding:
                 return .none
             case let .tapUser(id):
+                if !state.isEditable, id == nil {
+                    return .none
+                }
                 if let id = id,
                    let model = state.paticipators.first(where: { $0.id == id })
                 {
@@ -127,7 +135,7 @@ public struct AccountBookConfigStore {
                 state.destination = nil
                 return .none
             case .tapTopDone:
-                if state.saveDisable {
+                if !state.isEditable || state.saveDisable {
                     return .none
                 }
                 state.isSaving = true

--- a/Feature/Sources/AccountBookConfig/AccountBookConfigView.swift
+++ b/Feature/Sources/AccountBookConfig/AccountBookConfigView.swift
@@ -25,7 +25,11 @@ public struct AccountBookConfigView: View {
     public var body: some View {
         NavigationStack {
             scrollView
-            .navigationTitle(store.isCreate ? "add account book" : "edit account book")
+            .navigationTitle(
+                store.isEditable
+                    ? (store.isCreate ? "add account book" : "edit account book")
+                    : "account book detail"
+            )
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(action: {
@@ -65,6 +69,7 @@ public struct AccountBookConfigView: View {
                     .font(.headline)
                 TextField("Name Your Account Book", text: $store.name)
                     .textFieldStyle(.roundedBorder)
+                    .disabled(!store.isEditable)
 
                 if !store.isCreate {
                     Group {
@@ -76,6 +81,7 @@ public struct AccountBookConfigView: View {
                                 ParticipatorView(user: model) { user in
                                     store.send(.tapUser(user?.id))
                                 }
+                                .disabled(!store.isEditable && model == nil)
                             }
                         }
                     }
@@ -89,13 +95,36 @@ public struct AccountBookConfigView: View {
 
 struct AccountBookConfigView_Previews: PreviewProvider {
     static var previews: some View {
-        AccountBookConfigView(
-            Store(
-                initialState: AccountBookConfigStore.State(),
-                reducer: {
-                    AccountBookConfigStore()
-                }
+        Group {
+            AccountBookConfigView(
+                Store(
+                    initialState: AccountBookConfigStore.State(),
+                    reducer: {
+                        AccountBookConfigStore()
+                    }
+                )
             )
-        )
+            AccountBookConfigView(
+                Store(
+                    initialState: AccountBookConfigStore.State(
+                        book: .init(
+                            owner: .init(id: "owner-1", name: "Owner"),
+                            participacer: [
+                                .init(permission: .read, id: "1", name: "Alice"),
+                                .init(permission: .read, id: "2", name: "Bob")
+                            ],
+                            bills: [],
+                            id: "ledger-1",
+                            name: "Read Only Ledger",
+                            createdAt: "2023-10-01"
+                        ),
+                        isEditable: false
+                    ),
+                    reducer: {
+                        AccountBookConfigStore()
+                    }
+                )
+            )
+        }
     }
 }

--- a/Feature/Sources/AccountBookList/AccountBooklistStore.swift
+++ b/Feature/Sources/AccountBookList/AccountBooklistStore.swift
@@ -77,7 +77,7 @@ public struct AccountBooklistStore {
                 }
             case let .tapDetail(bookID: id):
                 if let book = state.books.first(where: { $0.id == id }) {
-                    state.accountBookConfig.book = book
+                    state.accountBookConfig = .init(book: book, isEditable: false)
                     return .run { send in
                         await send(.setPresent(true))
                     }


### PR DESCRIPTION
## Summary
- add an isEditable flag to AccountBookConfigStore state and prevent save interactions when read-only
- update AccountBooklistStore to pass read-only state when opening existing books
- disable editing controls in AccountBookConfigView and expand previews for editable vs read-only modes

## Testing
- swift test *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68cd620580d4832ea3cf6d16979c8b8a