### PR TITLE
Fix add accounts picker dismissal handling

### DIFF
--- a/Feature/Sources/Billslist/BillslistStore.swift
+++ b/Feature/Sources/Billslist/BillslistStore.swift
@@ -77,10 +77,16 @@ public struct BillslistStore {
                 state.ledger = ledger
                 state.bills = Self.makeBillSections(from: ledger)
                 return .none
+            case .destination(.presented(.addAccounts(.destination(.dismiss)))):
+                if case .addAccounts(var addAccountsState)? = state.destination {
+                    addAccountsState.isCameraPickerPresented = false
+                    addAccountsState.isPhotoLibraryPresented = false
+                    state.destination = .addAccounts(addAccountsState)
+                }
+                return .none
             case .destination(.presented(.addAccounts(.saveResponse(.success)))):
                 // Saving has completed successfully inside InputAccountsStore.
-                // Dismiss and refresh ledgers/bills.
-                state.destination = nil
+                // Refresh ledgers/bills.
                 return .run { send in
                     let ledgers = await ledgerClient.fetchLedgers()
                     await send(.ledgersResponse(ledgers))


### PR DESCRIPTION
## Summary
- reset the add accounts image picker flags when the picker dismisses without closing the sheet
- refresh ledgers after a successful save while leaving dismissal to the sheet-level dismiss action

## Testing
- Not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68cdf2d470e0832eb30ca538813fac74