### PR TITLE
Handle saved ledger navigation

### DIFF
--- a/Feature/Package.swift
+++ b/Feature/Package.swift
@@ -46,7 +46,10 @@ let package = Package(
         ),
         .testTarget(
             name: "RootTests",
-            dependencies: ["Root"]),
+            dependencies: [
+                "Root",
+                .product(name: "Core", package: "Core")
+            ]),
         .target(name: "AccountBookList",
                dependencies: coreDependencies + [
                 "AccountBookConfig",

--- a/Feature/Sources/Root/RootStore.swift
+++ b/Feature/Sources/Root/RootStore.swift
@@ -78,10 +78,7 @@ public struct RootStore {
                         state.destination = .addBook(AccountBookConfigStore.State())
                         return .none
                     }
-                    let billsState = BillslistStore.State(
-                        bills: Self.makeBillSections(from: ledger),
-                        ledger: ledger
-                    )
+                    let billsState = Self.makeBillsState(from: ledger)
                     state.bills = billsState
                     state.destination = .billslist(billsState)
                 }
@@ -92,11 +89,19 @@ public struct RootStore {
                     print("failed to get book from bookConfig")
                     return .none
                 }
-                let billSections = Self.makeBillSections(from: book)
-                let billsState = BillslistStore.State(bills: billSections, ledger: book)
-                state.bills = billsState
-                state.destination = .billslist(billsState)
+                Self.integrateSavedLedger(book, into: &state)
                 return .none
+            case .destination(.presented(.addBook(.onSaved))):
+                if case let .addBook(addBookState) = state.destination,
+                   let ledger = addBookState.book
+                {
+                    Self.integrateSavedLedger(ledger, into: &state)
+                    return .none
+                }
+                return .run { send in
+                    let ledgers = await ledgerClient.fetchLedgers()
+                    await send(.ledgersLoaded(ledgers))
+                }
             default:
                 return .none
             }
@@ -115,6 +120,25 @@ private extension RootStore {
                 cells: ledger.bills
             )
         ]
+    }
+
+    static func makeBillsState(from ledger: AccountBook) -> BillslistStore.State {
+        BillslistStore.State(
+            bills: makeBillSections(from: ledger),
+            ledger: ledger
+        )
+    }
+
+    static func integrateSavedLedger(_ ledger: AccountBook, into state: inout State) {
+        if let index = state.ledgers.firstIndex(where: { $0.id == ledger.id }) {
+            state.ledgers[index] = ledger
+        } else {
+            state.ledgers.insert(ledger, at: 0)
+        }
+
+        let billsState = makeBillsState(from: ledger)
+        state.bills = billsState
+        state.destination = .billslist(billsState)
     }
 }
 

--- a/Feature/Tests/RootTests/RootTests.swift
+++ b/Feature/Tests/RootTests/RootTests.swift
@@ -1,11 +1,35 @@
+import Core
 import XCTest
 @testable import Root
 
+@MainActor
 final class RootTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-//        XCTAssertEqual(Feature().text, "Hello, World!")
+    func testNavigateToBillsListAfterSavingFirstLedger() {
+        let savedLedger = AccountBook(
+            owner: .init(id: "owner-id", name: "Owner"),
+            participacer: [],
+            bills: [],
+            id: "ledger-id",
+            name: "My Ledger",
+            createdAt: "2024-02-09T12:00:00Z"
+        )
+
+        var state = RootStore.State(
+            ledgers: [],
+            destination: .addBook(AccountBookConfigStore.State(book: savedLedger))
+        )
+
+        _ = RootStore().reduce(into: &state, action: .destination(.presented(.addBook(.onSaved))))
+
+        XCTAssertEqual(state.ledgers, [savedLedger])
+        XCTAssertEqual(state.bills.ledger, savedLedger)
+        XCTAssertTrue(state.bills.bills.isEmpty)
+
+        switch state.destination {
+        case let .billslist(billsState):
+            XCTAssertEqual(billsState.ledger, savedLedger)
+        default:
+            XCTFail("Expected bills list destination after saving ledger")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle the add-book onSaved delegate from the destination reducer so that the saved ledger is promoted to the bills list
- refresh in-memory ledgers/bills with helper utilities when a ledger is saved
- add a regression test and expose the Core product to the RootTests target

## Testing
- `swift test` *(fails: Unable to clone https://github.com/pointfreeco/swift-composable-architecture because CONNECT tunnel failed with response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf2cc4338832eb7e24a45ca226012