### PR TITLE
Persist selected ledger across launches

### DIFF
--- a/Feature/Package.swift
+++ b/Feature/Package.swift
@@ -46,7 +46,10 @@ let package = Package(
         ),
         .testTarget(
             name: "RootTests",
-            dependencies: ["Root"]),
+            dependencies: [
+                "Root",
+                .product(name: "Core", package: "Core")
+            ]),
         .target(name: "AccountBookList",
                dependencies: coreDependencies + [
                 "AccountBookConfig",

--- a/Feature/Sources/Root/RootStore.swift
+++ b/Feature/Sources/Root/RootStore.swift
@@ -52,6 +52,7 @@ public struct RootStore {
     }
     
     @Dependency(\.ledgerClient) public var ledgerClient
+    @Dependency(\.preferences) public var preferences
 
     public init() {}
 
@@ -74,7 +75,11 @@ public struct RootStore {
                 if ledgers.isEmpty {
                     state.destination = .addBook(AccountBookConfigStore.State())
                 } else {
-                    guard let ledger = ledgers.first else {
+                    let savedID = preferences.value(forKey: "currentBook") as? String
+                    let matchedLedger = savedID.flatMap { id in
+                        ledgers.first(where: { $0.id == id })
+                    } ?? ledgers.first
+                    guard let ledger = matchedLedger else {
                         state.destination = .addBook(AccountBookConfigStore.State())
                         return .none
                     }

--- a/Feature/Tests/RootTests/RootTests.swift
+++ b/Feature/Tests/RootTests/RootTests.swift
@@ -1,11 +1,44 @@
 import XCTest
+import Core
 @testable import Root
 
+@MainActor
 final class RootTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-//        XCTAssertEqual(Feature().text, "Hello, World!")
+    func testLoadsPreferredLedgerAfterRestart() {
+        let owner = User(id: "owner", name: "Owner")
+        let firstLedger = AccountBook(
+            owner: owner,
+            participacer: [],
+            bills: [],
+            id: "ledger-1",
+            name: "Ledger 1",
+            createdAt: ""
+        )
+        let secondLedger = AccountBook(
+            owner: owner,
+            participacer: [],
+            bills: [],
+            id: "ledger-2",
+            name: "Ledger 2",
+            createdAt: ""
+        )
+        let ledgers = [firstLedger, secondLedger]
+
+        var state = RootStore.State()
+        let reducer = RootStore()
+
+        UserDefaults.standard.set(secondLedger.id, forKey: "currentBook")
+        defer { UserDefaults.standard.removeObject(forKey: "currentBook") }
+
+        _ = reducer.reduce(into: &state, action: .ledgersLoaded(ledgers))
+
+        XCTAssertEqual(state.ledgers, ledgers)
+        XCTAssertEqual(state.bills.ledger.id, secondLedger.id)
+        switch state.destination {
+        case .billslist(let billsState):
+            XCTAssertEqual(billsState.ledger.id, secondLedger.id)
+        default:
+            XCTFail("Expected bills list destination to be presented")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- inject the preferences dependency into `RootStore` and use saved `currentBook` to pick the initial ledger when ledgers load
- keep the previous first-ledger fallback when no saved selection exists
- add a regression test to ensure the saved ledger remains selected after restart and expose Core to the Root test target

## Testing
- `swift test` *(fails: unable to fetch https://github.com/pointfreeco/swift-composable-architecture due to CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf2d8793c832eb9bc12dc094e6d64