### PR TITLE
Move ledger decoding off main thread

### DIFF
--- a/Core/Sources/Core/Core/DataManager.swift
+++ b/Core/Sources/Core/Core/DataManager.swift
@@ -168,15 +168,16 @@ extension LedgerDataClient {
                 }
             }
 
-            let viewContext = container.viewContext
-            return await viewContext.perform {
+            let ledgers: [AccountBook] = await backgroundContext.perform {
                 objectIDs.compactMap { objectID in
-                    guard let ledger = try? viewContext.existingObject(with: objectID) as? LedgerEntity else {
+                    guard let ledger = try? backgroundContext.existingObject(with: objectID) as? LedgerEntity else {
                         return nil
                     }
                     return LedgerAdapter.from(entity: ledger)
                 }
             }
+
+            return await MainActor.run { ledgers }
         },
         addLedger: { title, ownerID, ownerName in
             let container = PersistenceController.shared.container

--- a/Feature/Package.swift
+++ b/Feature/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
             name: "RootTests",
             dependencies: [
                 "Root",
+                "Billslist",
                 .product(name: "Core", package: "Core")
             ]),
         .target(name: "AccountBookList",

--- a/Feature/Tests/RootTests/RootTests.swift
+++ b/Feature/Tests/RootTests/RootTests.swift
@@ -1,7 +1,7 @@
 import Core
 import XCTest
-import Core
 @testable import Root
+@testable import Billslist
 
 @MainActor
 final class RootTests: XCTestCase {
@@ -42,6 +42,7 @@ final class RootTests: XCTestCase {
         default:
             XCTFail("Expected bills list destination to be presented")
         }
+    }
 
     func testNavigateToBillsListAfterSavingFirstLedger() {
         let savedLedger = AccountBook(
@@ -70,5 +71,69 @@ final class RootTests: XCTestCase {
         default:
             XCTFail("Expected bills list destination after saving ledger")
         }
+    }
+}
+
+@MainActor
+final class BillslistStoreTests: XCTestCase {
+
+    func testLedgerResponseUpdatesVisibleLedgerAndBills() {
+        let owner = User(id: "owner", name: "Owner")
+        let initialLedger = AccountBook(
+            owner: owner,
+            participacer: [],
+            bills: [],
+            id: "ledger-1",
+            name: "Personal",
+            createdAt: ""
+        )
+
+        var state = BillslistStore.State(
+            bills: [],
+            ledger: initialLedger
+        )
+
+        let newerBill = Bill(
+            id: "bill-newer",
+            value: 20,
+            type: .income,
+            mainCategory: BillMainCategory(id: "main", name: "Main", subCategories: []),
+            subCategory: BillSubCategory(id: "sub", name: "Sub"),
+            createdAt: "2024-01-02T00:00:00Z",
+            updatedAt: "2024-01-02T12:00:00Z",
+            createdByUser: owner,
+            updatedByUser: owner,
+            description: "New income"
+        )
+
+        let olderBill = Bill(
+            id: "bill-older",
+            value: 10,
+            type: .payment,
+            mainCategory: BillMainCategory(id: "main", name: "Main", subCategories: []),
+            subCategory: BillSubCategory(id: "sub", name: "Sub"),
+            createdAt: "2024-01-01T00:00:00Z",
+            updatedAt: "2024-01-01T08:00:00Z",
+            createdByUser: owner,
+            updatedByUser: owner,
+            description: "Groceries"
+        )
+
+        let refreshedLedger = AccountBook(
+            owner: owner,
+            participacer: [],
+            bills: [olderBill, newerBill],
+            id: "ledger-1",
+            name: "Personal",
+            createdAt: ""
+        )
+
+        _ = BillslistStore().reduce(into: &state, action: .ledgersResponse([refreshedLedger]))
+
+        XCTAssertEqual(state.ledger, refreshedLedger)
+        XCTAssertEqual(
+            state.bills,
+            [BillSectionData(id: refreshedLedger.id, header: refreshedLedger.name, cells: [newerBill, olderBill])]
+        )
     }
 }


### PR DESCRIPTION
## Summary
- keep ledger fetching work inside the background Core Data context before hopping back to the main actor
- ensure Root and Billslist reducers still handle ledger refreshes by extending their unit tests
- expose the Billslist target to the Root test suite

## Testing
- swift test *(fails: unable to clone https://github.com/pointfreeco/swift-composable-architecture due to 403 CONNECT tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9c7757ec832e80ab8452ac51e128